### PR TITLE
Add a tip about composer and GitHub rate limitations

### DIFF
--- a/runtimes/php/php-apps.md
+++ b/runtimes/php/php-apps.md
@@ -138,7 +138,17 @@ Example of a `composer.json` file:
 }
 ```
 
-You can find more documentation at [getcomposer.com](https://getcomposer.org/doc/04-schema.md).
+#### GitHub rate limit
+
+To prevent download dependencies's fails like 
+
+```Failed to download symfony/symfony from dist: Could not authenticate against github.com```
+
+that is often caused by rate limit of GitHub API while deploying your apps, we recommend you to add `oauth` token in your composer configuration file or in separate file nammed as describe in [this](https://getcomposer.org/doc/articles/troubleshooting.md#api-rate-limit-and-oauth-tokens) FAQ entry.
+
+You can find more documentation about composer configuration at [getcomposer.com](https://getcomposer.org/doc/04-schema.md).
+
+
 
 ### Execute a custom script after the deploy
 


### PR DESCRIPTION
Add a paragraph about rate limitation of GitHub who can parasite the deployment of composer based php projects.

#### GitHub rate limit

To prevent download dependencies's fails like 

```Failed to download symfony/symfony from dist: Could not authenticate against github.com```

that is often caused by rate limit of GitHub API while deploying your apps, we recommend you to add `oauth` token in your composer configuration file or in separate file nammed as describe in [this](https://getcomposer.org/doc/articles/troubleshooting.md#api-rate-limit-and-oauth-tokens) FAQ entry.

You can find more documentation about composer configuration at [getcomposer.com](https://getcomposer.org/doc/04-schema.md).

