### PR TITLE
add version of postgres

### DIFF
--- a/commons/addons/postgresql.md
+++ b/commons/addons/postgresql.md
@@ -10,7 +10,12 @@ and on standards-compliance.
 
 ## PostgreSQL version
 
-The version currently installed by the add-on is PostgreSQL 9.2.8
+The version currently installed by the add-on is :
+
+- on shared plans (DEV and S) : PostgreSQL 9.2.8
+- on newly created dedicated databases (plans M and above) : Postgresql 9.3.4
+
+Note that PostgreSQL 9.4 branch (or 9.5 branch whe the final version will be released) will be rolled out as soon as possible on the dedicated databases plans.
 
 ## PostgreSQL plans
 

--- a/commons/addons/postgresql.md
+++ b/commons/addons/postgresql.md
@@ -15,7 +15,7 @@ The version currently installed by the add-on is :
 - on shared plans (DEV and S) : PostgreSQL 9.2.8
 - on newly created dedicated databases (plans M and above) : Postgresql 9.3.4
 
-Note that PostgreSQL 9.4 branch (or 9.5 branch whe the final version will be released) will be rolled out as soon as possible on the dedicated databases plans.
+Note that PostgreSQL 9.4 branch (or 9.5 branch when the final version will be released) will be rolled out as soon as possible on the dedicated databases plans.
 
 ## PostgreSQL plans
 

--- a/commons/addons/postgresql.md
+++ b/commons/addons/postgresql.md
@@ -8,6 +8,10 @@ position: 6
 PostgreSQL is an object-relational database management system (ORDBMS) with an emphasis on extensibility
 and on standards-compliance.
 
+## PostgreSQL version
+
+The version currently installed by the add-on is PostgreSQL 9.2.8
+
 ## PostgreSQL plans
 
 <table class="table table-bordered table-striped dataTable"><caption>PostgreSQL pricing plans</caption>


### PR DESCRIPTION
I think it's very very important to know the version of postgres installed by the add-on, because postgres is moving forward quite fast, and some very important features (json..) are only availables with versions 9.3 and 9.4.

For some apps, the version of the database may be a prerequisite.

I saw that on nodejs the add-on installed postgres 9.2.8, by the following sql command in pgStudio
 
     SELECT version;
I don't know if the same version is installed with the others platforms, please don't hesitate to comment.