### PR TITLE
Fix ruby.json example code.

### DIFF
--- a/runtimes/ruby/ruby.md
+++ b/runtimes/ruby/ruby.md
@@ -79,7 +79,7 @@ configuration file. This file is optional.
 {
   "deploy" : {
     "env": "<string>",
-    "rakegoals": [<string>]
+    "rakegoals": [<string>],
     "sidekiq": true
   }
 }


### PR DESCRIPTION
Added a missing comma in the clevercloud/ruby.json example.