### PR TITLE
Fix bad links for the clever-cloud-overview/add-application path

### DIFF
--- a/runtimes/java/java-maven.md
+++ b/runtimes/java/java-maven.md
@@ -30,7 +30,7 @@ Your application must be set to listen on the port 8080.
 
 ## Create an application
 
-Refer to the page [Deploy an application on Clever Cloud](/clever-cloud-overview/add-application/).
+Refer to the page [Deploy an application on Clever Cloud](/doc/clever-cloud-overview/add-application/).
 
 ## Necessary information
 

--- a/runtimes/nodejs/nodejs.md
+++ b/runtimes/nodejs/nodejs.md
@@ -19,7 +19,7 @@ Node.js is a platform built on Chrome's JavaScript runtime for building fast, sc
 
 ## Create an application
 
-Refer to the page [Deploy an application on Clever Cloud](/clever-cloud-overview/add-application/).
+Refer to the page [Deploy an application on Clever Cloud](/doc/clever-cloud-overview/add-application/).
 
 ## Necessary information
 


### PR DESCRIPTION
Related to issue #94 