### PR TITLE
Explain Github deployment limitations

### DIFF
--- a/commons/clever-cloud-overview/add-application.md
+++ b/commons/clever-cloud-overview/add-application.md
@@ -104,7 +104,16 @@ From now on, a push to your GitHub repo will also trigger a Clever Cloud deploym
 
 Note that only a push on master will trigger the deployment.
 
-Private GitHub repositories are also supported: you only have to add the <a href="https://github.com/CleverCloudDeployer">CleverCloudDeployer user</a> as a collaborator to your private repository. Note that read only access is sufficient.
+ <div class="alert alert-hot-problems">
+   <h4>Warning:</h4>
+   <p>You can't directly push to an application created on Clever Cloud as a Github app : in this case, only the automatic deployment from Github is henceforth allowed.</p>
+   <p>If you try to push to Clever Cloud, as you would do for a non-github app, you will get the following error :</p>
+   <pre>fatal: '/data/repositories/&lt;app_id&gt;.git' does not appear to be a git repository</pre>
+   <p>Indeed, no git repository is created on Clever Cloud because the application is directly cloned from Github.</p>
+   <p>If you have to push directly to a repo in order to deploy an application (eg if you deploy from a CI), then create a non-github app.</p>
+ </div>
+
+<strong>Private GitHub repositories are also supported:</strong> you only have to add the <a href="https://github.com/CleverCloudDeployer">CleverCloudDeployer user</a> as a collaborator to your private repository. Note that read only access is sufficient.
 
 Caution: in Github, private repositories in an ordinary user account are an all-or-nothing deal: either someone has full read/write access (i.e., they're a collaborator) or they have no access. However, if you set up an organization, create the repo under the aegis of the organization, and then add the collaborator, you have much more fine-grained control (including giving read-only access to a private repository).
 


### PR DESCRIPTION
Seen with Arnaud : one can't directly push to a github app, so if someone want to deploy from a CI by directly pushing, the app has to be created as a non-github app.

Feel free to edit the formatting, and perhaps also the writing style ?