### PR TITLE
Update java_version documentation

### DIFF
--- a/runtimes/java/select-java-version.md
+++ b/runtimes/java/select-java-version.md
@@ -9,12 +9,12 @@ tags:
 
 Simply set the environment variable **JAVA_VERSION** to the version you want
 
-Accepted values are `6`, `7` and `8`
+Accepted values are `7` and `8`
 
 <div class="alert alert-hot-problems">
 <h4>**Default version**</h4>
 We are still using Java version 7 by default for backward compatibility.<br/>
-New applications will have the **JAVA_VERSION** environment variable set to 7.
+However, new applications will have the **JAVA_VERSION** environment variable set to 8.
 </div>
 
 


### PR DESCRIPTION
Java 6 is no longer supported (at least on sbt applications, idk about the others), and new applications are created with `JAVA_VERSION` set to 8

poke @Keruspe (I'm not sure about java 6 support, especially with the java merge coming)