### PR TITLE
Update postgres version in docs

### DIFF
--- a/commons/addons/postgresql.md
+++ b/commons/addons/postgresql.md
@@ -22,9 +22,9 @@ and on standards-compliance.
 The version currently installed by the add-on is :
 
 - on shared plans (DEV and S) : PostgreSQL 9.2.8
-- on newly created dedicated databases (plans M and above) : Postgresql 9.3.4
+- on newly created dedicated databases (plans M and above) : Postgresql 9.5.4
 
-Note that PostgreSQL 9.4 branch (or 9.5 branch when the final version will be released) will be rolled out as soon as possible on the dedicated databases plans.
+Note that PostgreSQL 9.6 branch will be rolled out as soon as possible on the dedicated databases plans.
 
 ## PostgreSQL plans
 


### PR DESCRIPTION
According to weekly update n°2, pg version is as of now 9.5.4 on dedicated plans.
I also changed the sentence about the next version, as I assume that CleverCloud will roll out version 9.6 in the close future.