### PR TITLE
Update getting_started.md

### DIFF
--- a/commons/clever-tools/getting_started.md
+++ b/commons/clever-tools/getting_started.md
@@ -33,7 +33,7 @@ To install Clever Tools system-wide, run
 Clever Tools comes with a powerful auto-completion support. Make sure to
 enable it for a better experience.
 
-    install-clever-completion
+    sudo install-clever-completion
 
 ## Linking your account
 


### PR DESCRIPTION
sudo is necessary because `install-clever-completion` needs to create directory in `/usr/share/zsh/site-functions`.