### PR TITLE
Document docker socket access

### DIFF
--- a/runtimes/docker/docker.md
+++ b/runtimes/docker/docker.md
@@ -66,6 +66,22 @@ CMD <command to run>
    easier for you to put a script in your docker image and call it with
    the CMD instruction.
 
+### Docker socket access
+
+Some containers require access to the docker socket, to spawn sibling containers for instance.
+
+<div class="panel panel-warning">
+  <div class="panel-heading">
+    <h4 class="panel-title">Giving access to the docker socket breaks isolation</h4>
+  </div>
+  <div class="panel-body">
+    <p>
+    Giving access to the docker socket breaks all isolation provided by docker. <b>DO NOT</b> give socket access to untrusted code.
+    </p>
+  </div>
+</div>
+
+You can make the docker socket available from inside the container by adding `CC_MOUNT_DOCKER_SOCKET=true` in your application's environment variables. In that case, docker is started in the namespaced mode, and in bridge network mode.
 
 ### Sample apps
 
@@ -77,7 +93,7 @@ We provide a few examples of dockerized applications on Clever Cloud.
 [Seaside / Smalltalk App](https://github.com/CleverCloud/demo-seaside)
 [Rust App](https://github.com/CleverCloud/demo-rust)
 
-### Deploying a Rust application
+#### Deploying a Rust application
 
 To make your dockerized application run on clever Cloud, you need to:
 

--- a/runtimes/docker/docker.md
+++ b/runtimes/docker/docker.md
@@ -26,7 +26,7 @@ applications.
 
 Docker containers can encapsulate any payload, and will run consistently
 on and between virtually any server. The same container that a developer
-builds and tests on a laptop will run at scale, in production*, on VMs,
+builds and tests on a laptop will run at scale, in production, on VMs,
 bare-metal servers, public instances, or combinations of the above.
 
 ### Create an application


### PR DESCRIPTION
Closes #205 

Currently it's `MOUNT_DOCKER_SOCKET`, but it's only used internally from now, and it's changed to `CC_MOUNT_DOCKER_SOCKET` in the deployer's master branch