### PR TITLE
Add clever deploy to clever tools manage page

### DIFF
--- a/commons/clever-tools/manage.md
+++ b/commons/clever-tools/manage.md
@@ -30,6 +30,9 @@ If you want to restart your application, you can use :
 
 You can use `--quiet` when you restart, logs won't appear during deployment.
 
+## Deploy a new commit
+
+Use `clever deploy` to push your commits, which then starts a deployment
 
 ## Environment
 


### PR DESCRIPTION
There is no reference of `clever deploy` into the manage page of the clever tools documentation