### PR TITLE
Typo/Formatting in java-war.md

### DIFF
--- a/runtimes/java/java-war.md
+++ b/runtimes/java/java-war.md
@@ -36,7 +36,7 @@ The supported containers are listed below:
 </tr>
 </thead>
 <tbody>
-<tr><td>Apache Tomcat 4.1 (TOMCAT4)</td><td>Jetty 6.1 (JETTY6)</td><td>Jboss 6.1 (JBOSS6)</td><td>Glassfish 3.1 (GLASSFISH3)</td><td>Payara 4.1 (PAYARA4)</td><td>Resin 3.1 (RESIN3)</td><td> </td>WildFly 9.0.2 (WILDFLY9)</tr>
+<tr><td>Apache Tomcat 4.1 (TOMCAT4)</td><td>Jetty 6.1 (JETTY6)</td><td>Jboss 6.1 (JBOSS6)</td><td>Glassfish 3.1 (GLASSFISH3)</td><td>Payara 4.1 (PAYARA4)</td><td>Resin 3.1 (RESIN3)</td><td>WildFly 9.0.2 (WILDFLY9)</td></tr>
 <tr><td>Apache Tomcat 5.5 (TOMCAT5)</td><td>Jetty 7.6 (JETTY7)</td><td>Jboss AS 7.1 (JBOSS7)</td><td>Glassfish 4.1 (GLASSFISH4)</td><td> </td><td> </td><td> </td></tr>
 <tr><td>Apache Tomcat 6.0 (TOMCAT6)</td><td>Jetty 8.1 (JETTY8)</td><td> </td><td> </td><td> </td><td> </td><td> </td></tr>
 <tr><td>Apache Tomcat 7.0 (TOMCAT7)</td><td>Jetty 9.0 (JETTY9)</td><td> </td><td> </td><td> </td><td> </td><td> </td></tr>
@@ -284,6 +284,14 @@ Here's the list of the configuration values for the "container" field in `war.js
 <tr>
 <td>TOMCAT8</td>
 <td>Use Tomcat servlet container 8.x (see <a href="https://tomcat.apache.org/">https://tomcat.apache.org/</a>)</td>
+</tr>
+<tr>
+<td>PAYARA4</td>
+<td>Use Payara servlet container 4.x (see <a href="https://www.payara.fish/">https://www.payara.fish/</a>)</td>
+</tr>
+<tr>
+<td>WILDFLY9</td>
+<td>Use Wildfly servlet container 9.x (see <a href="http://wildfly.org/">http://wildfly.org/</a>)</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Wildfly deployment wasn't displaying properly in the table. Added PAYARA4 and WILDFLY9 in the "available containers" section for consistency (they were missing), but didn't test them, it may not be accurate.