### PR TITLE
Update monolog configuration inside Symfony

### DIFF
--- a/runtimes/php/tutorial-symfony.md
+++ b/runtimes/php/tutorial-symfony.md
@@ -44,7 +44,7 @@ From the CLI, it's even simpler: `clever env import < .env`.
 
 Make sure that Symfony send error level logs to error_log, then you will be able to read them in clever-cloud log console.
 
-Here is an exemple of monolog configuration that stores all log messages during a request but only writes them only if one of the messages reaches error level, and in all cases passes all error level message to error_log:
+Here is an exemple of monolog configuration that stores all log messages during a request but only send them to error_log if one of the messages reaches error level:
 
 ```
 monolog:
@@ -52,11 +52,10 @@ monolog:
         filter_for_errors:
             type: fingers_crossed
             action_level: error
-            handler: file_handler
-
-        file_handler:
-            type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            handler: error_log_handler
+            excluded_404s:
+                 # regex: exclude all 404 errors from the logs
+                 - ^/
 
         error_log_handler:
             type: error_log

--- a/runtimes/php/tutorial-symfony.md
+++ b/runtimes/php/tutorial-symfony.md
@@ -40,11 +40,11 @@ From the console, you can edit the application's environment variables. Click on
 From the CLI, it's even simpler: `clever env import < .env`.
 
 
-### Configure monolog to use syslog
+### Configure monolog to use error_log
 
-Make sure that Symfony send error level logs to syslog, then you will be able to read them in clever-cloud log console.
+Make sure that Symfony send error level logs to error_log, then you will be able to read them in clever-cloud log console.
 
-Here is an exemple of monolog configuration that stores all log messages during a request but only writes them only if one of the messages reaches error level, and in all cases passes all error level message to syslog:
+Here is an exemple of monolog configuration that stores all log messages during a request but only writes them only if one of the messages reaches error level, and in all cases passes all error level message to error_log:
 
 ```
 monolog:
@@ -58,9 +58,9 @@ monolog:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
 
-        syslog_handler:
-            type: syslog
-            level: error
+        error_log_handler:
+            type: error_log
+            level: warning
 ```
 
 


### PR DESCRIPTION
Hello :)

We just tweaked the monolog configuration for our [jolicode/secret-santa](https://github.com/jolicode/secret-santa) app to have logs displayed in the Clever Cloud console and thought it would be great to fix the docs at the same time :wink: 

- using `syslog` did not make logs appear in the console so we changed it to `error_log` instead
- as we normally do not access the running instance to consult the logs, we remove the logging to a file

Cheers :beers: 