### PR TITLE
ruby: drop uwsgi documentation

### DIFF
--- a/commons/get-help/reference-environment-variables.md
+++ b/commons/get-help/reference-environment-variables.md
@@ -551,12 +551,6 @@ So you can alter the build&start process for your application.
     <td></td>
   </tr>
   <tr>
-    <td>HARAKIRI</td>
-    <td>Timeout (in seconds) after which an unresponding process is killed</td>
-    <td>`180`</td>
-    <td></td>
-  </tr>
-  <tr>
     <td>RACK_ENV</td>
     <td></td>
     <td></td>

--- a/commons/get-help/reference-environment-variables.md
+++ b/commons/get-help/reference-environment-variables.md
@@ -593,54 +593,6 @@ So you can alter the build&start process for your application.
     <td></td>
   </tr>
   <tr>
-    <td>UWSGI_INTERCEPT_ERRORS</td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>[UWSGI_ASYNC](/doc/python/python_apps/#uwsgi-asynchronous-non-blocking-modes)</td>
-    <td>Number of cores to use for uWSGI asynchronous/non-blocking modes</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>UWSGI_ASYNC_ENGINE</td>
-    <td>Select the asynchronous engine for uWSGI (optional)</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>WSGI_WORKERS</td>
-    <td>Number of workers. (Defaut: automatically setup with the scaler size)</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>WSGI_THREADS</td>
-    <td>Number of threads per worker. (Defaut: automatically setup with the scaler size)</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>WSGI_BUFFER_SIZE</td>
-    <td>Buffer size (in bytes) for uploads.</td>
-    <td>`4096`</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>WSGI_POST_BUFFERING</td>
-    <td>Maximal size (in bytes) for the headers of a request. </td>
-    <td>`4096`</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>ENABLE_GZIP_COMPRESSION</td>
-    <td>Set to `true` to gzip-compress the output of uwsgi</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
     <td>NGINX_READ_TIMEOUT</td>
     <td>Read timeout in seconds</td>
     <td>`300`</td>

--- a/runtimes/docker/fluentd.md
+++ b/runtimes/docker/fluentd.md
@@ -103,7 +103,7 @@ $ curl 0.0.0.0:9292
      <h4>Why I can't just use ruby runtime</h4>
   </div>
   <div class="panel-body">
-    Ruby runtime on Clever Cloud requires **Puma** or **uWSGI** webserver but fluentd is using **excon**.
+    Ruby runtime on Clever Cloud requires **Puma** webserver but fluentd is using **excon**.
   </div>
 </div>
 

--- a/runtimes/ruby/ruby-on-rails.md
+++ b/runtimes/ruby/ruby-on-rails.md
@@ -70,14 +70,11 @@ greatest 2.5.Y. We provide also the 2.4.Y and 2.3.Y version.
 
 ## Choose rackup application server
 
-You can select the server by setting an environment variable `CC_RACKUP_SERVER=yourserver`
-where yourserver is one of `puma` or `uwsgi`. `puma` is the default application server from rails, and thus one
+You can select the server by setting an environment variable `CC_RACKUP_SERVER=yourserver`.
+The only available server as of now is `puma`. `puma` is the default application server from rails, and thus one
 of the most commonly used for ruby deployment.
 
 By default, when creating a new ruby application, an environment variable is automatically added: `CC_RACKUP_SERVER=puma`.
-
-If you remove this environment variable or set its value to `uwsgi`, your application will run using [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest/).
-uWSGI's main goal is to run as much as possible in parallel, thus aiming at being faster. Note that this is only supported for ruby 2.3.
 
 If you select puma, you will need to also add it to your dependencies: `bundle add puma`, and commit the resulting
 changes (this is automatic for projects generated using `rails new`).
@@ -208,23 +205,11 @@ task in the `rakegoals` field of `clevercloud/ruby.json`.
 }
 ```
 
-## uWSGI configuration
-
-uWSGI settings can be configured by setting environment variables:
-
- - `HARAKIRI`: timeout (in seconds) after which an unresponding process is killed. (Default: 180)
- - `WSGI_BUFFER_SIZE`: maximal size (in bytes) for the headers of a request. (Defaut: 4096)
- - `WSGI_POST_BUFFERING`: buffer size (in bytes) for uploads. (Defaut: 4096)
- - `WSGI_WORKERS`: number of workers. (Defaut: depends on the scaler)
- - `WSGI_THREADS`: number of threads per worker. (Defaut: depends on the scaler)
-
 ### nginx configuration
 
 nginx settings can be configured by setting environment variables:
 
  - `NGINX_READ_TIMEOUT`: a bit like HARAKIRI, the response timeout in seconds. (Defaut: 300)
- - `ENABLE_GZIP_COMPRESSION`: "on|yes|true" gzip-compress the output of uwsgi.
- - `UWSGI_INTERCEPT_ERRORS`: "on|off" intercept uwsgi errors
 
 Nginx settings can be configured further in `clevercloud/http.json`. All its fields are optional.
 
@@ -266,13 +251,6 @@ threads instead of a static number of threads.
 If specified, it will be preferred over the setting from `config/puma.rb`.
 If none is specified, we will setup the number of threads per worker depending on the size of the scaler your application is running on.
 We also fill the `RAILS_MAX_THREADS` environment variable if it's not present as it may be used by rails' puma configuration.
-
-## uWSGI asynchronous/non-blocking modes
-
-To enable [uWSGI asynchronous](https://uwsgi-docs.readthedocs.io/en/latest/Async.html) mode, you can use these two environment variables:
-
- - `UWSGI_ASYNC`: [number of cores](https://uwsgi-docs.readthedocs.io/en/latest/Async.html#async-switches) to use for uWSGI asynchronous/non-blocking modes.
- - `UWSGI_ASYNC_ENGINE`: select the [asynchronous engine for uWSGI](https://uwsgi-docs.readthedocs.io/en/latest/Async.html#suspend-resume-engines) (optional)
 
 ## Deploy on Clever Cloud
 

--- a/runtimes/ruby/ruby-on-rails.md
+++ b/runtimes/ruby/ruby-on-rails.md
@@ -209,7 +209,7 @@ task in the `rakegoals` field of `clevercloud/ruby.json`.
 
 nginx settings can be configured by setting environment variables:
 
- - `NGINX_READ_TIMEOUT`: a bit like HARAKIRI, the response timeout in seconds. (Defaut: 300)
+ - `NGINX_READ_TIMEOUT`: the response timeout in seconds. (Defaut: 300)
 
 Nginx settings can be configured further in `clevercloud/http.json`. All its fields are optional.
 


### PR DESCRIPTION
We only support it for ruby 2.3, which will be EOL in 3 months
