### PR TITLE
Fix sbt-native-packager section in the runtime scala doc

### DIFF
--- a/runtimes/scala/scala.md
+++ b/runtimes/scala/scala.md
@@ -30,13 +30,13 @@ We rely on `sbt-native-packager` to run applications. This plugin provides a
 
 ### Install `sbt-native-packager`
 
-If your project doesn't already use `sbt-native-packager`, you need to add it
+If your project doesn't already use [sbt-native-packager](https://github.com/sbt/sbt-native-packager), you need to add it
 to `project/plugins.sbt`. Please make sure you use an up-to-date version.
 
 In `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M9")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.18")
 ```
 
 Then you need to configure the package type:


### PR DESCRIPTION
This PR fix:
- the code to add `sbt-native-packager`  in project/plugins.sbt file
- add the URL of the `sbt-native-packager` to help the user if this section of the doc become out to date.