### PR TITLE
Improve clarity on workers configuration

### DIFF
--- a/commons/clever-cloud-overview/common-application-configuration.md
+++ b/commons/clever-cloud-overview/common-application-configuration.md
@@ -60,5 +60,5 @@ CC_WORKER_COMMAND_0=my-awesome-worker
 CC_WORKER_COMMAND_1=my-other-worker
 ```
 
-By default, a worker will be restarted if it exits with an error code. You can customise this behaviour by setting the
+By default, workers will be restarted if they exit with an error code. You can customise this behaviour by setting the
 environment variable `CC_WORKER_RESTART` to one of `always`, `on-failure` (the default) or `no`.

--- a/commons/get-help/reference-environment-variables.md
+++ b/commons/get-help/reference-environment-variables.md
@@ -83,13 +83,15 @@ So you can alter the build&start process for your application.
     <td>`false`</td>
   </tr>
   <tr>
-    <td>CC_WORKER_COMMAND</td>
-    <td>Command to run in background as a worker process.</td>
+    <td>[CC_WORKER_COMMAND](/doc/clever-cloud-overview/common-application-configuration/#workers)</td>
+    <td>Command to run in background as a worker process. You can run multiple worker.</td>
     <td></td>
   </tr>
   <tr>
     <td>CC_WORKER_RESTART</td>
-    <td>One of `always`, `on-failure` or `no`. Control whether a worker needs to be restarted when it exits</td>
+    <td>One of `always`, `on-failure` or `no`. Control whether workers need to be restarted when they exit.
+        This setting controls all workers.
+    </td>
     <td>on-failure</td>
   </tr>
   <tr>


### PR DESCRIPTION
Following a discussion with support, it appeared that documentation on workers was a tad unclear.