### PR TITLE
Update commons/addons/cellar-vs-fsbuckets.md

### DIFF
--- a/commons/addons/cellar-vs-fsbuckets.md
+++ b/commons/addons/cellar-vs-fsbuckets.md
@@ -19,7 +19,7 @@ Clever Cloud uses immutable disposable VMs.
 Every time you redeploy your application, you lose the old instances and all the files stored on their filesystems.
 If you want to avoid that, you have to store your important files outside of your instances.
 
-Cellar and FS Buckets both allow you to store files ouside of your instances for later
+Cellar and FS Buckets both allow you to store files outside of your instances for later
 use. But there are some differences between them.
 
 


### PR DESCRIPTION
Hi!

Fix typo `ouside` => `ouside` into  `commons/addons/cellar-vs-fsbuckets.md` documentation.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>