### PR TITLE
Remove legacy doc

### DIFF
--- a/runtimes/nodejs/nodejs.md
+++ b/runtimes/nodejs/nodejs.md
@@ -148,9 +148,6 @@ Here is an example :
 }
 ```
 
-As of now, we will always install development dependencies even if `NODE_ENV=production` is set, using either `npm install --production=false` or `yarn install --production=false`.
-An environment variable might be added in the future to let you control this behaviour. Please reach out to our support if you need such environment variable.
-
 #### Deploy with privates dependencies
 
 If your application got privates dependencies, you can add a [Private SSH Key](https://www.clever-cloud.com/doc/clever-cloud-overview/common-application-configuration/#private-ssh-key).


### PR DESCRIPTION
Since the new flag system to control the npm developement dependencies, I remove the old doc that presents the forcing of npm developement dependencies installation