### PR TITLE
Use a dedicated source.list file to install clever-tools on debian

### DIFF
--- a/commons/clever-tools/getting_started.md
+++ b/commons/clever-tools/getting_started.md
@@ -37,14 +37,14 @@ If you are using a GNU/Linux distribution that uses `.deb` packages like Debian 
 
 > Make sure you can download https hosted sources package. You may install :
   ```sh
-  apt-get install apt-transport-https ca-certificates
+  apt install apt-transport-https ca-certificates
   ```
 
 ```sh
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "379CE192D401AB61"
-echo "deb https://dl.bintray.com/clevercloud/deb stable main" | tee -a /etc/apt/sources.list
-apt-get update
-apt-get install clever-tools
+echo "deb https://dl.bintray.com/clevercloud/deb stable main" | tee -a /etc/apt/sources.list.d/clever.list
+apt update
+apt install clever-tools
 ```
 
 NOTES:

--- a/commons/clever-tools/getting_started.md
+++ b/commons/clever-tools/getting_started.md
@@ -42,7 +42,7 @@ If you are using a GNU/Linux distribution that uses `.deb` packages like Debian 
 
 ```sh
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "379CE192D401AB61"
-echo "deb https://dl.bintray.com/clevercloud/deb stable main" | tee -a /etc/apt/sources.list.d/clever.list
+echo "deb https://dl.bintray.com/clevercloud/deb stable main" | tee -a /etc/apt/sources.list.d/clevercloud.list
 apt update
 apt install clever-tools
 ```


### PR DESCRIPTION
It's much more convenient to have a file for each external repository