### PR TITLE
Update cellar.md for Nodejs

### DIFF
--- a/commons/addons/cellar.md
+++ b/commons/addons/cellar.md
@@ -116,7 +116,7 @@ const AWS = require('aws-sdk');
 
 AWS.config.update({accessKeyId: '<cellar_key_id>', secretAccessKey: '<cellar_key_secret>'});
 
-const s3 = new AWS.S3({ '<cellar_host>' });
+const s3 = new AWS.S3({ endpoint: '<cellar_host>' });
 
 s3.listBuckets(function(err, res) {
   // handle results

--- a/commons/addons/cellar.md
+++ b/commons/addons/cellar.md
@@ -115,9 +115,8 @@ You only need to specify a custom endpoint (eg `cellar-c2.services.clever-cloud.
 const AWS = require('aws-sdk');
 
 AWS.config.update({accessKeyId: '<cellar_key_id>', secretAccessKey: '<cellar_key_secret>'});
-const endpoint = new AWS.Endpoint('<cellar_host>');
 
-const s3 = new AWS.S3({ endpoint });
+const s3 = new AWS.S3({ '<cellar_host>' });
 
 s3.listBuckets(function(err, res) {
   // handle results


### PR DESCRIPTION
Fix : Type 'Endpoint' is not assignable to type 'string'