### PR TITLE
Update tutorial-symfony.md

### DIFF
--- a/runtimes/php/tutorial-symfony.md
+++ b/runtimes/php/tutorial-symfony.md
@@ -77,7 +77,7 @@ If you want to have database migrations automatically run during each deployment
 
 ```
 # Database migrations
-./bin/console doctrine:migrations:migrate
+./bin/console doctrine:migrations:migrate --no-interaction
 
 # Frontend build
 yarn run build


### PR DESCRIPTION
`bin/console doctrine:migrations:migrate` should be used with the `--no-interaction` attribute, otherwise the command will require user confirmation