### PR TITLE
docs: fix typos

### DIFF
--- a/account/manage-account.md
+++ b/account/manage-account.md
@@ -13,7 +13,7 @@ In the Clever Cloud Web Console, select **Profile** in the bottom left menu.
 
 You will see several menu entries.
 
-- **Information**: on that page you can edit your name, adress, phone number, profile picture, manage the link between your Clever Cloud and Github account and select the language of your Clever Cloud web console.
+- **Information**: on that page you can edit your name, address, phone number, profile picture, manage the link between your Clever Cloud and Github account and select the language of your Clever Cloud web console.
 
 - **Emails**: manage your linked email addresses.
 

--- a/administrate/domain-names.md
+++ b/administrate/domain-names.md
@@ -225,7 +225,7 @@ Remember that DNS changes may take time to propagate (usually a few hours, somet
     <tr>
       <td>``example.com``</td>
       <td>No CNAME record needed</td>
-      <td>point ``example.com`` to the two IP adresses of the selected region</td>
+      <td>point ``example.com`` to the two IP addresses of the selected region</td>
       <td>No redirect needed</td>
     </tr>
   </tboby>

--- a/administrate/log-management.md
+++ b/administrate/log-management.md
@@ -1,5 +1,5 @@
 ---
-title: Logs managment
+title: Logs management
 position: 3
 shortdesc: How to manage addons and applications log drains
 tags:

--- a/administrate/metrics/new-relic.md
+++ b/administrate/metrics/new-relic.md
@@ -40,7 +40,7 @@ Before setting up your app, be sure to have a [New Relic Account](https://www.ne
 
 ### Configuration
 
-To configure your New Relic, you need to set the environment variables `NEWRELIC_LICENSE` and `NEWRELIC_APPNAME` (optionnal).
+To configure your New Relic, you need to set the environment variables `NEWRELIC_LICENSE` and `NEWRELIC_APPNAME` (optional).
 
 Alternatively you can create and add a `./clevercloud/newrelic.json` file in your project, with the
 following fields:

--- a/billing/analytics-consumption.md
+++ b/billing/analytics-consumption.md
@@ -25,6 +25,6 @@ In the console, the consumption of each apps is displayed
 
 If your apps is experiencing upscale and downscale frequently, like several times per month, your monthly invoice amount will not be exactly the same each month, if auto-scalability is enabled (in your app preferences, tab "Scaling").
 
-Most of our cutomers apps running with auto-scaling enabled have less than a ±5% variation between consecutive months in their invoice. Especially because upscale events don't last for long before a downscale occurs, usually after 2-3 hours. High trafic is most of the time temporary (a newsletter sendings, a TV show appearence, Techcrunch effect etc.).
+Most of our cutomers apps running with auto-scaling enabled have less than a ±5% variation between consecutive months in their invoice. Especially because upscale events don't last for long before a downscale occurs, usually after 2-3 hours. High traffic is most of the time temporary (a newsletter sendings, a TV show appearance, Techcrunch effect etc.).
 
 In the end, auto-scaling is pretty useful to avoid applications slowdown with a significant impact on your billing.

--- a/deploy/addon/cellar.md
+++ b/deploy/addon/cellar.md
@@ -42,7 +42,7 @@ You can download a s3cmd configuration file from the add-on configuration page.
 </tr>
 </table>
 
-<table class="table table-bordered table-striped dataTable"><caption>Cellar trafic usage plans</caption>
+<table class="table table-bordered table-striped dataTable"><caption>Cellar traffic usage plans</caption>
 <tr>
 <th>Traffic (outbound)</th>
 <th>Price / GB / month</th>

--- a/deploy/addon/jenkins.md
+++ b/deploy/addon/jenkins.md
@@ -34,4 +34,4 @@ Jenkins comes with the following pre-installed plugins:
 
  ## Backup
 
-By default, Clever Cloud perfoms a free backup every day, with a retention of three days. Retention and frequency can be customized for Premium customers. Each backup can be found in the add-on dashboard in the web console, along with the credentials.
+By default, Clever Cloud performs a free backup every day, with a retention of three days. Retention and frequency can be customized for Premium customers. Each backup can be found in the add-on dashboard in the web console, along with the credentials.

--- a/develop/best-practices/12-factors.md
+++ b/develop/best-practices/12-factors.md
@@ -10,9 +10,9 @@ keywords:
 - best practices
 ---
 
-The twelve-factor app is a methodology for writing sofware delivered as a service, wich is what you are doing by pushing your code to Clever Cloud and for container deployment in general. By writing code following these principles, your application will be cloud ready by design.
+The twelve-factor app is a methodology for writing software delivered as a service, which is what you are doing by pushing your code to Clever Cloud and for container deployment in general. By writing code following these principles, your application will be cloud ready by design.
 
-As a lot has already been writen on the subject, we strongly recommend that you read some of the following links to begin with this methodology:
+As a lot has already been written on the subject, we strongly recommend that you read some of the following links to begin with this methodology:
 
 - [https://en.wikipedia.org/wiki/Twelve-Factor_App_methodology](https://en.wikipedia.org/wiki/Twelve-Factor_App_methodology)
 - [https://www.clearlytech.com/2014/01/04/12-factor-apps-plain-english/](https://www.clearlytech.com/2014/01/04/12-factor-apps-plain-english/)

--- a/partials/add-ssh-keys-short-version.md
+++ b/partials/add-ssh-keys-short-version.md
@@ -10,7 +10,7 @@ SSH keys are used to establish a secure connection between your computer and Cle
     ```
     This command creates a new ssh key using the provided email, so that the owner of the key can be identified.
 
-2.  When prompted in wich file you want to save the key, just press entrer.
+2.  When prompted in which file you want to save the key, just press entrer.
     If it says that the file already exists, enter `n` for `no`. Type `ls`, constat the presence of the file and jump to [Add your SSH key on Clever Cloud](#AddYourSSHKeysOnCleverCloud). 
 
 3.  When asked, enter a passphrase:

--- a/partials/db-backup.md
+++ b/partials/db-backup.md
@@ -1,3 +1,3 @@
 ## Database Daily Backup and Retention
 
-By default, Clever Cloud perfoms a free backup every day, with a retention of seven days. Retention and frequency can be customized for Premium customers. Each backup can be found in the add-on dashboard in the web console, along with the credentials.
+By default, Clever Cloud performs a free backup every day, with a retention of seven days. Retention and frequency can be customized for Premium customers. Each backup can be found in the add-on dashboard in the web console, along with the credentials.

--- a/partials/env-injection.md
+++ b/partials/env-injection.md
@@ -1,3 +1,3 @@
 ## Environment injection
 
-Clever Cloud injects environment variables from your application settings as mentionned in [setting up environment variables](#setting-up-environment-variables-on-clever-cloud) and is also injecting in your application production environment, those from your [linked add-ons](#linking-a-database-or-any-other-add-on-to-your-application).
+Clever Cloud injects environment variables from your application settings as mentioned in [setting up environment variables](#setting-up-environment-variables-on-clever-cloud) and is also injecting in your application production environment, those from your [linked add-ons](#linking-a-database-or-any-other-add-on-to-your-application).

--- a/reference/clever-tools/manage.md
+++ b/reference/clever-tools/manage.md
@@ -39,7 +39,7 @@ Clever-tools allows you to get and update the environment of your application.
 
 ### Get the whole environment
 
-Simply use the commmand down below to get all your variables.
+Simply use the command down below to get all your variables.
 
     clever env
 


### PR DESCRIPTION
Hey,

This huge PR will fix : 

- 1 typo in `account/manage-account.md`
- 1 typo in `administrate/domain-names.md`
- 1 typo in `administrate/log-management.md`
- 1 typo in `administrate/metrics/new-relic.md`
- 1 typo in `billing/analytics-consumption.md`
- 1 typo in `deploy/addon/cellar.md`
- 1 typo in `deploy/addon/jenkins.md`
- 2 typos in `develop/best-practices/12-factors.md`
- 1 typo in `partials/add-ssh-keys-short-version.md`
- 1 typo in `partials/db-backup.md`
- 1 typo in `partials/env-injection.md`
- 1 typo in `reference/clever-tools/manage.md`



Best! :robot: