### PR TITLE
Mention automatic vacuuming for postgres

### DIFF
--- a/deploy/addon/postgresql.md
+++ b/deploy/addon/postgresql.md
@@ -392,3 +392,9 @@ PostgreSQL dedicated addons can be encrypted using LUKS with `aes-xts`.
 The passphrase is encrypted in our database using Cipher and Nonce as bytes arrays.
 
 To enable it, you need to ask to our support then we will perform invoicing configuration (more informations about pricing are available through support) and enable the encryption for your addon. Once it's done, you will need to migrate your addon then the encryption at rest will be up.
+
+## Automatic vacuuming
+
+Autovacuum (https://www.postgresql.org/docs/current/routine-vacuuming.html) is automatically enabled on postgres addons.  
+The autovacuum will proceed when a given percentage of rows of a table will be updated/inserted/deleted.  
+Usually this threshold is set to 20%.


### PR DESCRIPTION
Follow up of my conversation with Marc-Antoine

![image](https://user-images.githubusercontent.com/7466144/103629812-13e25280-4f41-11eb-9fc2-574f7b1dcc9b.png)

It's useful to mention this in the docs, because it's not obvious to know there's a threshold.  
It would be also usefull to precise the parameters (vacuum simple ? full ? and if the vacuum is scheduled at a fixed hour)