### PR TITLE
Varnish Availability disclaimer

### DIFF
--- a/administrate/cache.md
+++ b/administrate/cache.md
@@ -19,7 +19,7 @@ and the client. Following rules defined by the user, Varnish will cache the data
 
 {{< alert "warning" >}}
 <p>Varnish is only available on PHP >= 5.5 applications. Support for other applications is in discussion.</p> 
-<p>For more information about it, contact us at <support@clever-cloud.com>.</p>
+<p>For more information about it, contact us at <a href="mailto:support@clever-cloud.com">support@clever-cloud.com</a>.</p>
 {{< /alert >}}
 
 ## Enable Varnish for your application

--- a/administrate/cache.md
+++ b/administrate/cache.md
@@ -15,12 +15,15 @@ keywords:
 [Varnish](https://www.varnish-cache.org/) is a HTTP proxy-cache, which works as a reverse proxy between your application
 and the client. Following rules defined by the user, Varnish will cache the data of an application to reduce the load on its server. We use **Varnish 4**
 
+## Limitations
+
+Varnish is only available on PHP >= 5.5 applications. Support for other applications is in discussion. 
+For more information about it, contact us at <support@clever-cloud.com>.
+
 ## Enable Varnish for your application
 
 To enable it, you just have to create a `varnish.vcl` file in the `/clevercloud` folder.
 This file describes how Varnish caches your applications and how it decides to return a cached resource or not.
-
-Varnish is provided by default in PHP >= 5.5 instances.
 
 
 {{< alert "warning" >}}

--- a/administrate/cache.md
+++ b/administrate/cache.md
@@ -17,14 +17,15 @@ and the client. Following rules defined by the user, Varnish will cache the data
 
 ## Limitations
 
-Varnish is only available on PHP >= 5.5 applications. Support for other applications is in discussion. 
-For more information about it, contact us at <support@clever-cloud.com>.
+{{< alert "warning" >}}
+<p>Varnish is only available on PHP >= 5.5 applications. Support for other applications is in discussion.</p> 
+<p>For more information about it, contact us at <support@clever-cloud.com>.</p>
+{{< /alert >}}
 
 ## Enable Varnish for your application
 
 To enable it, you just have to create a `varnish.vcl` file in the `/clevercloud` folder.
 This file describes how Varnish caches your applications and how it decides to return a cached resource or not.
-
 
 {{< alert "warning" >}}
 <p>The <code>vcl 4.0;</code> and backend section of the `varnish.vcl` configuration file are not necessary as they are already handled by Clever Cloud.</p>


### PR DESCRIPTION
Update the Varnish cache page to make the availability restrictions clearer.

After contacting the support, I've been told that Varnish was only available on PHP applications.
The formulation in the doc was misleading and led to think that it was provided by default for PHP apps, but available for others once a `/clevercloud/varnish.vcl` valid file was created.

I think this will avoid further issues like this.