### PR TITLE
Fix typo links in env vars reference

### DIFF
--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -39,7 +39,7 @@ So you can alter the build&start process for your application.
  | <center>Name</center> | <center>Description</center> | <center>Default value</center> |
  |-----------------------|------------------------------|--------------------------------|
  |APP_FOLDER | Folder in which the application is located (inside the git repository) |  |
- |[CC_TROUBLESHOOT](({{< ref "find-help/troubleshooting.md" >}}) | Enable debug log level, will also keep the VM up after failure for 15 minutes so you can SSH and debug. Don't forget to cancel deployment if you push a new commit. | `false` |
+ |[CC_TROUBLESHOOT]({{< ref "find-help/troubleshooting.md" >}}) | Enable debug log level, will also keep the VM up after failure for 15 minutes so you can SSH and debug. Don't forget to cancel deployment if you push a new commit. | `false` |
  |[CC_WORKER_COMMAND]({{< ref "reference/common-configuration.md#workers" >}}) | Command to run in background as a worker process. You can run multiple worker. |  |
  |CC_WORKER_RESTART | One of `always`, `on-failure` or `no`. Control whether workers need to be restarted when they exit.<br />This setting controls all workers. | on-failure |
  |CC_PRE_BUILD_HOOK | Ran before the dependencies are fetched. If it fails, the deployment fails. |  |
@@ -54,7 +54,7 @@ So you can alter the build&start process for your application.
  |[IGNORE_FROM_BUILDCACHE]({{< ref "develop/env-variables.md#settings-you-can-define-using-environment-variables" >}}) | Allows to specify paths to ignore when the build cache archive is created. |  |
  |[CC_OVERRIDE_BUILDCACHE]({{< ref "develop/env-variables.md#settings-you-can-define-using-environment-variables" >}}) | Allows to specify paths that will be in the build cache. <br />Only those files / directories will be cached |  |
  |[CC_METRICS_PROMETHEUS_PORT]({{< ref "administrate/metrics/overview.md#publish-your-own-metrics" >}}) | Define the port on which the Prometheus endpoint is available | `8080` |
- |[CC_METRICS_PROMETHEUS_PATH](({{< ref "administrate/metrics/overview.md#publish-your-own-metrics" >}}) | Define the path on which the Prometheus endpoint is available | `/metrics` |
+ |[CC_METRICS_PROMETHEUS_PATH]({{< ref "administrate/metrics/overview.md#publish-your-own-metrics" >}}) | Define the path on which the Prometheus endpoint is available | `/metrics` |
  {{< /table >}}
 
 ## Docker


### PR DESCRIPTION
A very little fix for links in environment variables reference page :)