### PR TITLE
Add env var reference link in env variable page

### DIFF
--- a/develop/env-variables.md
+++ b/develop/env-variables.md
@@ -32,6 +32,8 @@ Variables are defined on a per-application basis. They are defined in four ways:
 Please note that if you define or modify environment variables, you will
 need to redeploy your application to make it use the new variables.
 
+Check out our [environment variable reference]({{< ref "reference/reference-environment-variables.md" >}}).
+
 ## Special environment variables
 
 Some variables are injected to the environment of your application when you deploy it,


### PR DESCRIPTION
There is no link to environment variable reference in env-variables page, I thought it might be useful to add one.