### PR TITLE
Update ruby version env variable

### DIFF
--- a/partials/language-specific-deploy/ruby.md
+++ b/partials/language-specific-deploy/ruby.md
@@ -14,7 +14,7 @@ You need to provide a `gems.locked` or `Gemfile.lock` file. To do that ensure yo
 
 If you specify a ruby version in your `gems.rb` of `Gemfile`, we'll use it, otherwise; keep reading.
 
-On your Clever Cloud application create an [environment variable](#setting-up-environment-variables-on-clever-cloud) `RUBY_VERSION=rubyversion` where `rubyversion` represents:
+On your Clever Cloud application create an [environment variable](#setting-up-environment-variables-on-clever-cloud) `CC_RUBY_VERSION=rubyversion` where `rubyversion` represents:
 
  * "2" will select the greatest "2.X.Y" version available.
  * "2.5" will select the greatest "2.5.Y" version available.

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -205,7 +205,7 @@ So you can alter the build&start process for your application.
  |CC_RACKUP_SERVER | The server to use for serving the ruby application | puma |  |
  |RACK_ENV |  |  |  |
  |RAILS_ENV |  |  |  |
- |RUBY_VERSION | Choose the Ruby version to use. |  |  |
+ |CC_RUBY_VERSION | Choose the Ruby version to use but we strongly advise to set Ruby version in your Gemfile |  |  |
  |STATIC_FILES_PATH | Relative path to where your static files are stored: `path/to/static` |  |  |
  |[STATIC_URL_PREFIX]({{< ref "deploy/application/python/python_apps.md#configure-your-python-application" >}}) | The URL path under which you want to serve static file, usually `/public` |  |  |
  |STATIC_WEBROOT |  |  |  |


### PR DESCRIPTION
Users should now use `CC_RUBY_VERSION` but also prefer version definition in their Gemfile.