### PR TITLE
Add standard output and error section to cron

### DIFF
--- a/administrate/cron.md
+++ b/administrate/cron.md
@@ -136,3 +136,7 @@ fi
 cd ${APP_HOME} # Which has been loaded by the env.
 … # Your part here
 ```
+
+## Standard Output & Error
+
+Everything coming from stdout & stderr is forwarded to syslog and is available in the console logs.

--- a/administrate/cron.md
+++ b/administrate/cron.md
@@ -137,6 +137,6 @@ cd ${APP_HOME} # Which has been loaded by the env.
 … # Your part here
 ```
 
-## Standard Output & Error
+## Logs collection
 
-Everything coming from stdout & stderr is forwarded to syslog and is available in the console logs.
+Everything coming from stdout & stderr is forwarded to our logs collection system and is available in the web console / CLI logs.


### PR DESCRIPTION
A little precision as some users might want to redirect it without knowing it will be available in the console logs.