### PR TITLE
Add Elastic Stack env variables

### DIFF
--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -338,7 +338,6 @@ So you can alter the build&start process for your application.
  |ES_ADDON_VERSION |  | ElasticSearch Version | 7  |
  {{< /table >}}
 
-
 ## New Relic
 
  {{<table "table table- bordered" "text-align:center" >}}

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -324,18 +324,18 @@ So you can alter the build&start process for your application.
  {{<table "table table- bordered" "text-align:center" >}}
  | <center>Name</center> | <center>Description</center> | <center>Default value</center> | <center>Read Only</center> |
  |-----------------------|------------------------------|--------------------------------|--------------------------------|
- |ES_ADDON_APM_AUTH_TOKEN |  | Generated upon creation | X  |
- |ES_ADDON_APM_HOST |  | Generated upon creation | X  |
- |ES_ADDON_APM_PASSWORD |  | Generated upon creation | X  |
- |ES_ADDON_APM_USER |  | Generated upon creation | X  |
- |ES_ADDON_HOST |  | Generated upon creation | X  |
- |ES_ADDON_KIBANA_HOST |  | Generated upon creation | X  |
- |ES_ADDON_KIBANA_PASSWORD |  | Generated upon creation | X  |
- |ES_ADDON_KIBANA_USER |  | Generated upon creation | X  |
- |ES_ADDON_PASSWORD |  | Generated upon creation | X  |
- |ES_ADDON_URI |  | Generated upon creation | X  |
- |ES_ADDON_USER |  | Generated upon creation | X  |
- |ES_ADDON_VERSION |  | ElasticSearch Version | 7  |
+ |ES_ADDON_APM_HOST | APM Server hostname | Generated upon creation | X  |
+ |ES_ADDON_APM_AUTH_TOKEN | Authentication token to send metrics to APM Server | Generated upon creation | X  |
+ |ES_ADDON_APM_USER | Username credential used by APM Server to send metrics to Elasticsearch | Generated upon creation | X  |
+ |ES_ADDON_APM_PASSWORD | Password credential used by APM Server to send metrics to Elasticsearch | Generated upon creation | X  |
+ |ES_ADDON_KIBANA_HOST | Kibana hostname | Generated upon creation | X  |
+ |ES_ADDON_KIBANA_USER | Username credential used by Kibana to query Elasticsearch | Generated upon creation | X  |
+ |ES_ADDON_KIBANA_PASSWORD | Password credential used by Kibana to query Elasticsearch | Generated upon creation | X  |
+ |ES_ADDON_URI | URI to query Elasticsearch | Generated upon creation | X  |
+ |ES_ADDON_HOST | Elasticsearch hostname | Generated upon creation | X  |
+ |ES_ADDON_USER | Username credential to authenticate to Elasticsearch | Generated upon creation | X  |
+ |ES_ADDON_PASSWORD | Username credential to authenticate to Elasticsearch | Generated upon creation | X  |
+ |ES_ADDON_VERSION | ElasticSearch Version | 7 | X  |
  {{< /table >}}
 
 ## New Relic

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -324,8 +324,10 @@ So you can alter the build&start process for your application.
  {{<table "table table- bordered" "text-align:center" >}}
  | <center>Name</center> | <center>Description</center> | <center>Default value</center> | <center>Read Only</center> |
  |-----------------------|------------------------------|--------------------------------|--------------------------------|
+ |ELASTIC_APM_SERVER_URLS | TODO | Generated upon creation | X  |
  |ES_ADDON_APM_HOST | APM Server hostname | Generated upon creation | X  |
  |ES_ADDON_APM_AUTH_TOKEN | Authentication token to send metrics to APM Server | Generated upon creation | X  |
+ |ELASTIC_APM_SECRET_TOKEN | TODO | Generated upon creation | X  |
  |ES_ADDON_APM_USER | Username credential used by APM Server to send metrics to Elasticsearch | Generated upon creation | X  |
  |ES_ADDON_APM_PASSWORD | Password credential used by APM Server to send metrics to Elasticsearch | Generated upon creation | X  |
  |ES_ADDON_KIBANA_HOST | Kibana hostname | Generated upon creation | X  |

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -317,6 +317,27 @@ So you can alter the build&start process for your application.
  |REDIS_PASSWORD |  | Generated upon creation | X  |
  {{< /table >}}
 
+## Elastic Stack
+
+[Elastic Stack Documentation]({{< ref "deploy/addon/elastic.md" >}})
+
+ {{<table "table table- bordered" "text-align:center" >}}
+ | <center>Name</center> | <center>Description</center> | <center>Default value</center> | <center>Read Only</center> |
+ |-----------------------|------------------------------|--------------------------------|--------------------------------|
+ |ES_ADDON_APM_AUTH_TOKEN |  | Generated upon creation | X  |
+ |ES_ADDON_APM_HOST |  | Generated upon creation | X  |
+ |ES_ADDON_APM_PASSWORD |  | Generated upon creation | X  |
+ |ES_ADDON_APM_USER |  | Generated upon creation | X  |
+ |ES_ADDON_HOST |  | Generated upon creation | X  |
+ |ES_ADDON_KIBANA_HOST |  | Generated upon creation | X  |
+ |ES_ADDON_KIBANA_PASSWORD |  | Generated upon creation | X  |
+ |ES_ADDON_KIBANA_USER |  | Generated upon creation | X  |
+ |ES_ADDON_PASSWORD |  | Generated upon creation | X  |
+ |ES_ADDON_URI |  | Generated upon creation | X  |
+ |ES_ADDON_USER |  | Generated upon creation | X  |
+ |ES_ADDON_VERSION |  | ElasticSearch Version | 7  |
+ {{< /table >}}
+
 
 ## New Relic
 

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -324,10 +324,10 @@ So you can alter the build&start process for your application.
  {{<table "table table- bordered" "text-align:center" >}}
  | <center>Name</center> | <center>Description</center> | <center>Default value</center> | <center>Read Only</center> |
  |-----------------------|------------------------------|--------------------------------|--------------------------------|
- |ELASTIC_APM_SERVER_URLS | TODO | Generated upon creation | X  |
+ |ELASTIC_APM_SERVER_URLS | URI to connect APM Server | Generated upon creation | X  |
  |ES_ADDON_APM_HOST | APM Server hostname | Generated upon creation | X  |
  |ES_ADDON_APM_AUTH_TOKEN | Authentication token to send metrics to APM Server | Generated upon creation | X  |
- |ELASTIC_APM_SECRET_TOKEN | TODO | Generated upon creation | X  |
+ |ELASTIC_APM_SECRET_TOKEN | Authentication token to send metrics to APM Server | Generated upon creation | X  |
  |ES_ADDON_APM_USER | Username credential used by APM Server to send metrics to Elasticsearch | Generated upon creation | X  |
  |ES_ADDON_APM_PASSWORD | Password credential used by APM Server to send metrics to Elasticsearch | Generated upon creation | X  |
  |ES_ADDON_KIBANA_HOST | Kibana hostname | Generated upon creation | X  |

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -334,7 +334,7 @@ So you can alter the build&start process for your application.
  |ES_ADDON_URI | URI to query Elasticsearch | Generated upon creation | X  |
  |ES_ADDON_HOST | Elasticsearch hostname | Generated upon creation | X  |
  |ES_ADDON_USER | Username credential to authenticate to Elasticsearch | Generated upon creation | X  |
- |ES_ADDON_PASSWORD | Username credential to authenticate to Elasticsearch | Generated upon creation | X  |
+ |ES_ADDON_PASSWORD | Password credential to authenticate to Elasticsearch | Generated upon creation | X  |
  |ES_ADDON_VERSION | ElasticSearch Version | 7 | X  |
  {{< /table >}}
 


### PR DESCRIPTION
The environment variables from the Elastic Stack addon were missing in the environment variables reference.