### PR TITLE
Fix wrong database configuration in symfony tutorial

### DIFF
--- a/deploy/application/php/tutorials/tutorial-symfony.md
+++ b/deploy/application/php/tutorials/tutorial-symfony.md
@@ -96,7 +96,9 @@ Symfony got your back on this: just run `composer require symfony/apache-pack`. 
 
 ## Configure your database
 
-Make sure you have created a database add-on in the Clever Cloud console, and that it's linked to your application. When it's done, you will be able to access all of your add-on [environment variables](#setting-up-environment-variables-on-clever-cloud) from the application. You can use them as  `DATABASE_URL=$MYSQL_ADDON_URI`.
+Make sure you have created a database add-on in the Clever Cloud console, and that it's linked to your application. When it's done, you will be able to access all of your add-on [environment variables](#setting-up-environment-variables-on-clever-cloud) from the application.
+
+Change the default `DATABASE_URL` environment variable used in your `config/packages/doctrine.yaml` to `MYSQL_ADDON_URI` or be sure to use the environment variable in your production configuration file as explained in the [configuration documentation of Symfony](https://symfony.com/doc/current/configuration.html#configuration-environments).
 
 ### Optional: run tasks after build step
 

--- a/deploy/application/php/tutorials/tutorial-symfony.md
+++ b/deploy/application/php/tutorials/tutorial-symfony.md
@@ -98,7 +98,7 @@ Symfony got your back on this: just run `composer require symfony/apache-pack`. 
 
 Make sure you have created a database add-on in the Clever Cloud console, and that it's linked to your application. When it's done, you will be able to access all of your add-on [environment variables](#setting-up-environment-variables-on-clever-cloud) from the application.
 
-Change the default `DATABASE_URL` environment variable used in your `config/packages/doctrine.yaml` to `MYSQL_ADDON_URI` or be sure to use the environment variable in your production configuration file as explained in the [configuration documentation of Symfony](https://symfony.com/doc/current/configuration.html#configuration-environments).
+Change the default `DATABASE_URL` environment variable used in your `config/packages/doctrine.yaml` to `<ADDON_PREFIX>_ADDON_URI` where `<ADDON_PREFIX>` depending on the database addon you created (e.g. `MYSQL` for MySQL, `POSTGRESQL` for PostgreSQL or `MONGODB` for MongoDB) or be sure to use the environment variable in your production configuration file as explained in the [configuration documentation of Symfony](https://symfony.com/doc/current/configuration.html#configuration-environments).
 
 ### Optional: run tasks after build step
 


### PR DESCRIPTION
Database configuration instruction in Symfony tutorial does not work as variable injection only work with env file.