### PR TITLE
Fix minor spelling errors

### DIFF
--- a/account/ssh-keys-managment.md
+++ b/account/ssh-keys-managment.md
@@ -34,8 +34,8 @@ If a key is used by more than one account, a warning will be displayed in the co
     ```
     This command creates a new ssh key using the provided email, so that the owner of the key can be identified.
 
-2.  When prompted in wich file you want to save the key, just press entrer.
-    If it says that the file already exists, enter `n` for `no`. Type `ls`, constat the presence of the file and jump to [Add your SSH key on Clever Cloud](#AddYourSSHKeysOnCleverCloud). 
+2.  When prompted in which file you want to save the key, just press enter.
+    If it says that the file already exists, enter `n` for `no`. Type `ls`, verify the presence of the file and jump to [Add your SSH key on Clever Cloud](#AddYourSSHKeysOnCleverCloud).
 
 3.  When asked, enter a passphrase:
 
@@ -69,7 +69,7 @@ You may already have an SSH key and so do not need to generate a new one. To che
 
 #### Linux and Mac
 
-1. Wether you use Mac or Linux, open your Terminal application.
+1. Whether you use Mac or Linux, open your Terminal application.
 2. Run `cd ~/.ssh/` in your Terminal.
 3. If the folder exists, run `ls` and check if a pair of key exists : *id_ed25519* and *id_ed25519.pub*.
    Using *id_rsa* and *id_rsa.pub* is fine too. We are just advocating the use of *ed25519*.

--- a/contribute/shortcodes.md
+++ b/contribute/shortcodes.md
@@ -65,7 +65,7 @@ This shortcode will embed the clever-tools readme.
 
 ## tooltip shortcode
 
-Use the `tooltip` shortcode to provide a definition of the a term in a tooltip. All terms defintions are fetched from the glossary under `/data/glossary.json`.
+Use the `tooltip` shortcode to provide a definition of the a term in a tooltip. All terms definitions are fetched from the glossary under `/data/glossary.json`.
 the `title` parameter is the identifier of the object from `glossary.json`.
 
 This tooltip

--- a/deploy/addon/cellar.md
+++ b/deploy/addon/cellar.md
@@ -197,7 +197,7 @@ public class Main {
 
 This has been tested against python 3.6
 
-This script uses boto, the old implentation of the aws-sdk in python. Make sure to not use boto3, the API is completely different. For the moment, the host endpoint is `cellar-c2.services.clever-cloud.com` (but check in the clever cloud console).
+This script uses boto, the old implementation of the aws-sdk in python. Make sure to not use boto3, the API is completely different. For the moment, the host endpoint is `cellar-c2.services.clever-cloud.com` (but check in the clever cloud console).
 
 ```python
 from boto.s3.key import Key

--- a/deploy/addon/config-provider.md
+++ b/deploy/addon/config-provider.md
@@ -20,7 +20,7 @@ of your environment variables triggers automatic deployment of the linked applic
 
 Click on "Add an add-on", then choose "Configuration provider" and select the applications
 you want to link. On the dashboard, click on "edit" and input the environment variables.
-The syntax is `NAME=value`, like in the "expert mode" of the environment variables pannel of any application.
+The syntax is `NAME=value`, like in the "expert mode" of the environment variables panel of any application.
 Once you click "Save", all the linked applications will be restarted.
 
 ## Pricing

--- a/deploy/addon/elastic.md
+++ b/deploy/addon/elastic.md
@@ -40,9 +40,9 @@ Any member of the Clever Cloud organisation containing the Elastic add-on will b
 
 ## Elastic APM
 
-Elastic APM is an Application performance management tool chain based on the Elastic Stack. See exactly where your application is spending time so you can quickly fix issues and feel good about the code you push. To use it you must install an *APM agent* to your application. Once both your application and APM server are running, you application with automatically send APM datas to the APM server wich will send them to Elastic and once indexed they will be available in your Kibana dashboard (this process is really fast, you won't see it as a human).
+Elastic APM is an Application performance management tool chain based on the Elastic Stack. See exactly where your application is spending time so you can quickly fix issues and feel good about the code you push. To use it you must install an *APM agent* to your application. Once both your application and APM server are running, you application with automatically send APM datas to the APM server which will send them to Elastic and once indexed they will be available in your Kibana dashboard (this process is really fast, you won't see it as a human).
 
-Curently, APM agents are available in the following languages:
+Currently, APM agents are available in the following languages:
 - [Go](https://www.elastic.co/guide/en/apm/agent/go/1.x/introduction.html)
 - [Java](https://www.elastic.co/guide/en/apm/agent/java/1.x/intro.html)
 - [Node.js](https://www.elastic.co/guide/en/apm/agent/nodejs/2.x/intro.html)

--- a/deploy/addon/fs-bucket.md
+++ b/deploy/addon/fs-bucket.md
@@ -114,7 +114,7 @@ It's a json array containing objects with at least two fields:
 <td><span class="label label-danger">Required</span></td>
 <td>bucket</td>
 <td>The bucket id you can find in the console. It begins with `bucket_`. This is for
-"old-style" buckets (created before the 7 december 2015)</td>
+"old-style" buckets (created before the 7 December 2015)</td>
 </tr>
 <tr>
 <td><span class="label label-danger">Required</span></td>
@@ -175,7 +175,7 @@ variable, see [special environment variables]({{< ref "develop/env-variables.md#
 The **File explorer** tab of the **addon dashboard** gives you access to your files
 in the FS bucket.
 
-### From your favourite FTP client
+### From your favorite FTP client
 
 The **Addon information** tab of your FS Bucket add-on displays the information
 you need to connect to your bucket using FTP.

--- a/deploy/addon/postgresql.md
+++ b/deploy/addon/postgresql.md
@@ -339,7 +339,7 @@ Keep in mind that usage of direct access is a trade-off: when you migrate your a
 
 ## Default extensions
 
-Every PostgreSQL database mananged by Clever Cloud comes with the following default extensions:
+Every PostgreSQL database managed by Clever Cloud comes with the following default extensions:
 `adminpack`,
 `autoinc`,
 `btree_gin`,

--- a/deploy/application/python/tutorials/python-flask-sample-app.md
+++ b/deploy/application/python/tutorials/python-flask-sample-app.md
@@ -32,7 +32,7 @@ Clever Cloud runs the "app" Flask application defined in the `hello.py` file. So
 
 ### Fine tuning the application
 
-You can find a lot more configration options such as choosing python version and so [here]({{< ref "/deploy/application/python/python_apps.md" >}})
+You can find a lot more configuration options such as choosing python version and so [here]({{< ref "/deploy/application/python/python_apps.md" >}})
 
 {{< readfile "/content/partials/new-relic.md" >}}
 

--- a/deploy/clever-grid/clevergrid.md
+++ b/deploy/clever-grid/clevergrid.md
@@ -92,7 +92,7 @@ You can pass some parameter to your application by **environments variables**.
 
 ### Python applications
 
-If there is a `requirements.txt` in the root folder of your application, depedencies will be installed during the deployment.
+If there is a `requirements.txt` in the root folder of your application, dependencies will be installed during the deployment.
 
 * Starting file
   * Clever Grid need to know  which file runs to start your application. That can be a python file, declare in the

--- a/develop/best-practices/blue-green.md
+++ b/develop/best-practices/blue-green.md
@@ -12,25 +12,25 @@ keywords:
 Blue/Green deployment is a technique used in automated deployment of applications, databases and services.
 Its main goal is to minimize the downtime and risks of an application by running two identical environment instances, one called *Blue* and the other one called *Green*.
 
-## Contextual exemple
+## Contextual example
 
 Let's say you have a production environment called *Blue*, running for instance an e-commerce application. Your customers are routed to this *Blue* instance. In parallel, you will have a "sleeping clone" of *Blue*, named *Green*.
 Now let's say you have achieved a new feature and want your customers to benefit of it. Using the "Blue/Green" technique, the new code will be used in *Green*. Once *Green* is ready, you will redirect your customers to *Green*, and we will put *Blue* in "sleeping mode". When you will add new modification you will do it on *Blue* this time, then on *Green* again, and so on.
 
 There are many benefits to this approach:
 -  if *Green* fails to deploy there will be no downtime for your customers or users as you will not use the broken *Green* and stay on "Blue" until you fix your code so it can start
-- if you are not happy with the changes you added in *Green*, you can "awake" *Blue* and get back to the previous version easliy by routing the traffic to it
+- if you are not happy with the changes you added in *Green*, you can "awake" *Blue* and get back to the previous version easily by routing the traffic to it
 
 
 ## In the Clever Cloud context
 
 When you push your source code to the Clever Cloud git remote, Clever Cloud will automatically use the "Blue/Green" pattern to apply your changes to your production.
 
-A new VM, let's call it *Blue* is created. The deployment is successful when there's no error in the build phase and the server answers on :8080/ with a non error code. And that's it, you will use the new version on production within secondes.
+A new VM, let's call it *Blue* is created. The deployment is successful when there's no error in the build phase and the server answers on :8080/ with a non error code. And that's it, you will use the new version on production within seconds.
 
 If you push new changes, a *Green* VM will be created.
 
-#### Deploment succeeds
+#### Deployment succeeds
 If the deployment succeeds, *Green* will be the version in production and *Blue* will be turned off minutes later.
 This way, if you are not happy with the changes you made, just go the Clever Cloud web console, select your application and in the **Overview** menu, click the "Start last pushed commit" button, this will "awake" *Blue* and reverse your changes in production within a few minutes.
 

--- a/develop/best-practices/cloud-storage.md
+++ b/develop/best-practices/cloud-storage.md
@@ -19,7 +19,7 @@ Clever Cloud uses immutable disposable VMs.
 Every time you redeploy your application, you lose the old instances and all the files stored on their filesystems.
 If you want to avoid that, you have to store your important files outside of your instances.
 
-Cellar and FS Buckets both allow you to store files ouside of your instances for later use. But there are some differences between them.
+Cellar and FS Buckets both allow you to store files outside of your instances for later use. But there are some differences between them.
 
 {{< alert "info" "Don't want to read the guide?" >}}
     If you are coding a new project and need to store files, use Cellar. It will be cheaper and give you way more flexibility.<br />

--- a/getting-started/quickstart.md
+++ b/getting-started/quickstart.md
@@ -142,14 +142,14 @@ matching your application's ID. You will find the FTP credentials in the configu
 {{< /alert >}}
 
 {{< alert "warning" "Our advice:" >}}
-<p>FTP deployment is ok for small websites but not for large ones. We strongly ecommend you to use <b>Git</b> deployment for <b>large PHP websites</b>.</p>
+<p>FTP deployment is ok for small websites but not for large ones. We strongly recommend you to use <b>Git</b> deployment for <b>large PHP websites</b>.</p>
 {{< /alert >}}
 
 ### Application management generalities
 
 There are many tabs available in the application's menu:
 
-- Information: General informations about your application
+- Information: General information about your application
 - Scalability: Set-up scalability options
 - Domain names: Manage custom domain names
 - Environment variables: Manage environment variables
@@ -162,7 +162,7 @@ There are many tabs available in the application's menu:
 
 ## Create your first add-on
 
-Applications often requires one or more services in addition to the runtime itself. Add-ons are services you can use independantely, or you can link them with your application(s). For instance, you may want to add a database or a caching system to your application or just have a database with no linked application.
+Applications often requires one or more services in addition to the runtime itself. Add-ons are services you can use independently, or you can link them with your application(s). For instance, you may want to add a database or a caching system to your application or just have a database with no linked application.
 
 An add-on can be shared by different applications to share data between them. It can be a database shared by two or three applications of your infrastructure for example, or they can be independent.
 
@@ -231,7 +231,7 @@ To link an already existing add-on with your application, just follow these step
 
 ### Managing your add-on
 
-Once an add-on is created, at least two managment tabs are available in the Clever Cloud console:
+Once an add-on is created, at least two management tabs are available in the Clever Cloud console:
 
 * the Information tab
 * the Configuration tab

--- a/partials/add-ssh-keys-short-version.md
+++ b/partials/add-ssh-keys-short-version.md
@@ -10,8 +10,8 @@ SSH keys are used to establish a secure connection between your computer and Cle
     ```
     This command creates a new ssh key using the provided email, so that the owner of the key can be identified.
 
-2.  When prompted in which file you want to save the key, just press entrer.
-    If it says that the file already exists, enter `n` for `no`. Type `ls`, constat the presence of the file and jump to [Add your SSH key on Clever Cloud](#AddYourSSHKeysOnCleverCloud). 
+2.  When prompted in which file you want to save the key, just press enter.
+    If it says that the file already exists, enter `n` for `no`. Type `ls`, verify the presence of the file and jump to [Add your SSH key on Clever Cloud](#AddYourSSHKeysOnCleverCloud). 
 
 3.  When asked, enter a passphrase:
 

--- a/partials/authentication.md
+++ b/partials/authentication.md
@@ -13,7 +13,7 @@ Do not forget to validate your email by clicking the link you will receive.
 ### GitHub Authentication
 
 The GitHub signup allows you to create an account or link your existing one to GitHub, in one click.
-This process asks the following permsissions: 
+This process asks the following permissions: 
 
 * Read your Public Key
 * Read User Repositories

--- a/partials/create-application.md
+++ b/partials/create-application.md
@@ -11,6 +11,6 @@ Refer to {{< ref "/getting-started/" >}} for more details on application creatio
 
 ### via the Clever Tools CLI
 1. Make sure you have clever-tools installed locally. Report to {{< ref "/reference/clever-tools/getting_started.md" >}}
-2. In your code folder, do `clever create --type <type> <app-name> --region <zone> --org <org>` where `type` is the type of technology you rely on, `app-name` the name you want for your application, `zone` deloyment zone (`par` for Paris and `mtl` for Montreal), and `org` the organization ID the application will be created under.
+2. In your code folder, do `clever create --type <type> <app-name> --region <zone> --org <org>` where `type` is the type of technology you rely on, `app-name` the name you want for your application, `zone` deployment zone (`par` for Paris and `mtl` for Montreal), and `org` the organization ID the application will be created under.
 
 Refer to {{< ref "/reference/clever-tools/create.md" >}} for more details on application creation with Clever Tools.

--- a/partials/language-specific-deploy/docker.md
+++ b/partials/language-specific-deploy/docker.md
@@ -40,7 +40,7 @@ You can make the docker socket available from inside the container by adding the
 We support pulling private images through the `docker build` command. To login to a private registry, you need to set a few [environment variables](#setting-up-environment-variables-on-clever-cloud):
 - `CC_DOCKER_LOGIN_USERNAME`: the username to use to login
 - `CC_DOCKER_LOGIN_PASSWORD`: the password of your username
-- `CC_DOCKER_LOGIN_SERVER` (optionnal): the server of your private registry. Defaults to Docker's public registry.
+- `CC_DOCKER_LOGIN_SERVER` (optional): the server of your private registry. Defaults to Docker's public registry.
 
 This uses the `docker login` command under the hood.
 

--- a/partials/ssh-keys.md
+++ b/partials/ssh-keys.md
@@ -18,8 +18,8 @@ If a key is used by more than one account, a warning will be displayed in the co
     ```
     This command creates a new ssh key using the provided email, so that the owner of the key can be identified.
 
-2.  When prompted in wich file you want to save the key, just press entrer.
-    If it says that the file already exists, enter `n` for `no`. Type `ls`, constat the presence of the file and jump to [Add your SSH key on Clever Cloud](#add-your-ssh-key-on-clever-cloud). 
+2.  When prompted in which file you want to save the key, just press enter.
+    If it says that the file already exists, enter `n` for `no`. Type `ls`, verify the presence of the file and jump to [Add your SSH key on Clever Cloud](#add-your-ssh-key-on-clever-cloud).
 
 3.  When asked, enter a passphrase:
 
@@ -53,7 +53,7 @@ You may already have an SSH key and so do not need to generate a new one. To che
 
 #### Linux and Mac
 
-1. Wether you use Mac or Linux, open your Terminal application.
+1. Whether you use Mac or Linux, open your Terminal application.
 2. Run `cd ~/.ssh/` in your Terminal.
 3. If the folder exists, run `ls` and check if a pair of key exists : *id_ed25519* and *id_ed25519.pub*.
    Using *id_rsa* and *id_rsa.pub* is fine too. We are just advocating the use of *ed25519*.
@@ -121,7 +121,7 @@ First, you need to add the file `clevercloud/ssh.json`, its content is pretty st
 }
 ```
 
-The `privateKeyFile` field must be a path to a SSH private key. The path must be relativevto the root of your repository. e.g. if your private key file is in the `clevercloud` folder and is named `my_key`, the `privateKeyFile` field will be `"clevercloud/my_key"`.
+The `privateKeyFile` field must be a path to a SSH private key. The path must be relative to the root of your repository. e.g. if your private key file is in the `clevercloud` folder and is named `my_key`, the `privateKeyFile` field will be `"clevercloud/my_key"`.
 
 ## Check your ssh configuration
 

--- a/reference/common-configuration.md
+++ b/reference/common-configuration.md
@@ -42,7 +42,7 @@ First, you need to add the file `clevercloud/ssh.json`, its content is pretty st
 }
 ```
 
-The `privateKeyFile` field must be a path to a SSH private key. The path must be relativevto the root of your repository. e.g. if your private key file is in the `clevercloud` folder and is named `my_key`, the `privateKeyFile` field will be `"clevercloud/my_key"`.
+The `privateKeyFile` field must be a path to a SSH private key. The path must be relative to the root of your repository. e.g. if your private key file is in the `clevercloud` folder and is named `my_key`, the `privateKeyFile` field will be `"clevercloud/my_key"`.
 
 ## Hooks
 
@@ -57,7 +57,7 @@ Those are especially useful for environments where you can't have long-running p
 
 The workers run in the same environment as your application. They are launched in the application's directory.
 
-All you need to do is add one (or several) envrionment variables as such:
+All you need to do is add one (or several) environment variables as such:
 
 ```
 CC_WORKER_COMMAND=my-awesome-worker
@@ -70,5 +70,5 @@ CC_WORKER_COMMAND_0=my-awesome-worker
 CC_WORKER_COMMAND_1=my-other-worker
 ```
 
-By default, workers will be restarted if they exit with an error code. You can customise this behaviour by setting the
+By default, workers will be restarted if they exit with an error code. You can customise this behavior by setting the
 environment variable `CC_WORKER_RESTART` to one of `always`, `on-failure` (the default) or `no`.

--- a/reference/lexic.md
+++ b/reference/lexic.md
@@ -9,5 +9,5 @@ keywords:
 - glossary
 ---
 
-All terms available in this Lexic can be linked anywhere in the documentation thanks to the [tooltipe shortcode]({{< ref "contribute/shortcodes.md#tooltip-shortcode" >}}).
+All terms available in this Lexic can be linked anywhere in the documentation thanks to the [tooltip shortcode]({{< ref "contribute/shortcodes.md#tooltip-shortcode" >}}).
 {{< lexic >}}


### PR DESCRIPTION
This PR just fix some minor spelling errors I found when I was reading these documentation pages.

I used `aspell check` and only fixed spelling errors, no style (organisation vs organization), conventions (addons vs add-ons) or word cases  (Github vs GitHub) were changed.

I didn't find any open issues related to this but I can open a new issue if you want.

Please feel free to request any changes or drop this PR if it's not relevant. Thanks