### PR TITLE
Update database addon pricing tables

### DIFF
--- a/deploy/addon/mongodb.md
+++ b/deploy/addon/mongodb.md
@@ -18,12 +18,237 @@ MongoDB is an open source NoSQL document-oriented database. We provide these dat
 
 The version currently installed by the add-on is :
 
-- on shared plans (Peanut) : MongoDB 4.0.3
-- on newly created dedicated databases (plans Hazelnut and above) : MongoDB 4.0.3
+- on shared plan (DEV) : 4.0.3
+- on dedicated databases (XS Small Space and above) : 4.0.3
+
+## MongoDB plans
+
+<table class="table table-bordered table-striped dataTable">
+    <caption>MongoDB pricing plans</caption>
+    <tr>
+        <th>Name</th>
+        <th>DB size</th>
+        <th>Memory</th>
+        <th>Type</th>
+        <th>VCPUS</th>
+        <th>Price / Month</th>
+        <th>Logs & Metrics</th>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">DEV</span>
+        </td>
+        <td>500 MB</td>
+        <td>Shared</td>
+        <td>Shared</td>
+        <td>Shared</td>
+        <td>Free</td>
+        <td>No</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">XS Small Space</span>
+        </td>
+        <td>5 GB</td>
+        <td>1 GB</td>
+        <td>Decicated</td>
+        <td>1</td>
+        <td>17.50 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">XS Medium Space</span>
+        </td>
+        <td>15 GB</td>
+        <td>1 GB</td>
+        <td>Decicated</td>
+        <td>1</td>
+        <td>22.50 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">XS Big Space</span>
+        </td>
+        <td>30 GB</td>
+        <td>1 GB</td>
+        <td>Decicated</td>
+        <td>1</td>
+        <td>30.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">S Small Space</span>
+        </td>
+        <td>15 GB</td>
+        <td>2 GB</td>
+        <td>Decicated</td>
+        <td>2</td>
+        <td>37.50 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">S Medium Space</span>
+        </td>
+        <td>30 GB</td>
+        <td>2 GB</td>
+        <td>Decicated</td>
+        <td>2</td>
+        <td>45.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">S Big Space</span>
+        </td>
+        <td>50 GB</td>
+        <td>2 GB</td>
+        <td>Decicated</td>
+        <td>2</td>
+        <td>55.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">M Small Space</span>
+        </td>
+        <td>50 GB</td>
+        <td>4 GB</td>
+        <td>Decicated</td>
+        <td>4</td>
+        <td>97.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">M Medium Space</span>
+        </td>
+        <td>80 GB</td>
+        <td>4 GB</td>
+        <td>Decicated</td>
+        <td>4</td>
+        <td>112.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">M Big Space</span>
+        </td>
+        <td>100 GB</td>
+        <td>4 GB</td>
+        <td>Decicated</td>
+        <td>4</td>
+        <td>122.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">L Small Space</span>
+        </td>
+        <td>100 GB</td>
+        <td>8 GB</td>
+        <td>Decicated</td>
+        <td>6</td>
+        <td>194.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">L Medium Space</span>
+        </td>
+        <td>200 GB</td>
+        <td>8 GB</td>
+        <td>Decicated</td>
+        <td>6</td>
+        <td>244.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">L Big Space</span>
+        </td>
+        <td>300 GB</td>
+        <td>8 GB</td>
+        <td>Decicated</td>
+        <td>6</td>
+        <td>294.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">XL Small Space</span>
+        </td>
+        <td>300 GB</td>
+        <td>16 GB</td>
+        <td>Decicated</td>
+        <td>8</td>
+        <td>438.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">XL Medium Space</span>
+        </td>
+        <td>450 GB</td>
+        <td>16 GB</td>
+        <td>Decicated</td>
+        <td>8</td>
+        <td>513.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">XL Medium Space</span>
+        </td>
+        <td>600 GB</td>
+        <td>16 GB</td>
+        <td>Decicated</td>
+        <td>8</td>
+        <td>588.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">XXL Small Space</span>
+        </td>
+        <td>600 GB</td>
+        <td>32 GB</td>
+        <td>Decicated</td>
+        <td>10</td>
+        <td>1000.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">XXL Medium Space</span>
+        </td>
+        <td>750 GB</td>
+        <td>32 GB</td>
+        <td>Decicated</td>
+        <td>10</td>
+        <td>1075.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price ">
+            <span class="label cc-label__price label-info">XXL Big Space</span>
+        </td>
+        <td>900 GB</td>
+        <td>32 GB</td>
+        <td>Decicated</td>
+        <td>10</td>
+        <td>1150.00 €</td>
+        <td>Yes</td>
+    </tr>
+</table>
 
 ## About Free Databases
 
-Free plans are recommended for test and development usage only. Using these databases in production is not recommended, because performance may vary depending on the global usage of the cluster. Therefore, before switching to production, consider upgrading to a dedicated database for better performance.
+Free plans are recommended for test and development usage only. Using these databases in production is not recommended, because performance may vary depending on the global usage of the cluster.
+Therefore, before switching to production, consider upgrading to a dedicated database for better performance.
 
 ### Important Note About Fair Use on Free Databases
 
@@ -44,48 +269,6 @@ The process consists in three steps:
 1. First, perform a backup and download it, either with the Clever Cloud add-on dashboard or the `mongodump` command from your workstation.
 2. Install `mongorestore` (a tool packaged with [MongoDB](https://docs.mongodb.com/manual/administration/install-community/))
 3. On your workstation, use the taylor-made `mongorestore` command line located in your mongodb dashboard page. If needed, change the `nsFrom` and `nsTo` flags, depending on what you actually want to do (importing this database in another, importing another to this one, ...)
-
-
-## MongoDB plans
-
-<table class="table table-bordered table-striped dataTable"><caption>MongoDB pricing plans</caption>
-<tr>
-<th>Name</th>
-<th>Disk</th>
-<th>Cache (Memory)</th>
-<th>Price /mo</th>
-</tr>
-<tr>
-<td class="cc-col__price "><span class="label cc-label__price label-info">Peanut</span></td>
-<td>500 MB</td>
-<td>SHARED</td>
-<td>Free</td>
-</tr>
-<tr>
-<td class="cc-col__price "><span class="label cc-label__price label-info">Hazelnut</span></td>
-<td>1 GB</td>
-<td>512 MB</td>
-<td>20.00€</td>
-</tr>
-<tr>
-<td class="cc-col__price "><span class="label cc-label__price label-info">Shamrock</span></td>
-<td>5 GB</td>
-<td>1 GB</td>
-<td>40.00€</td>
-</tr>
-<tr>
-<td class="cc-col__price "><span class="label cc-label__price label-info">Vine</span></td>
-<td>30 GB</td>
-<td>2 GB</td>
-<td>75.00€</td>
-</tr>
-<tr>
-<td class="cc-col__price "><span class="label cc-label__price label-info">Gunnera</span></td>
-<td>100 GB</td>
-<td>4 GB</td>
-<td>150.00€</td>
-</tr>
-</table>
 
 ## Encryption at rest
 

--- a/deploy/addon/mysql.md
+++ b/deploy/addon/mysql.md
@@ -17,269 +17,316 @@ MySQL is an open-source relational database management system (RDBMS).
 
 The version currently installed by the add-on is :
 
-- on shared plans (DEV) : MySQL 8.0
-- on newly created dedicated databases (plans XS Small Space and above) : MySQL 5.7.20 or 8.0
+- on shared plan (DEV) : 8.0
+- on dedicated databases (XXS Small Space and above) : 5.7 or 8.0
 
 ## MySQL plans
 
 {{< alert "warning" "Note for Shared databases" >}}
-    As Shared databases (DEV) are shared between multiple applications and delays could appear in case of
-  an high demand.<br />
-  If this delays create problems in your application or are problematcs, we recommend you to use a dedicated database
-  (XS plans and above).
+  <p>As Shared databases (DEV) are shared between multiple applications and delays could appear in case of a high demand.</p>
+  <p>If this delays create problems in your application or are problematcs, we recommend you to use a dedicated database (XS plans and above).</p>
 {{< /alert >}}
 
-
-<table class="table table-bordered table-striped dataTable"><caption>MySQL pricing plans</caption>
-<tr>
-<th>Name</th>
-<th>Logs</th>
-<th>DB size</th>
-<th>Conn. limit</th>
-<th>Memory</th>
-<th>Type</th>
-<th>VCPUS</th>
-<th>Price /mo</th>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">DEV</span></td>
-<td>no</td>
-<td>10 MB</td>
-<td>5</td>
-<td>Shared</td>
-<td>Shared</td>
-<td>Shared</td>
-<td>Free</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXS Small Space</span></td>
-<td>yes</td>
-<td>512 MB</td>
-<td>15</td>
-<td>512 MB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>5.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXS Medium Space</span></td>
-<td>yes</td>
-<td>1 GB</td>
-<td>15</td>
-<td>512 MB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>5.90 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXS Big Space</span></td>
-<td>yes</td>
-<td>2 GB</td>
-<td>15</td>
-<td>512 MB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>6.80 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XS Tiny Space</span></td>
-<td>yes</td>
-<td>2 GB</td>
-<td>75</td>
-<td>1 GB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>13.00 €</td>
-</tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XS Small Space</span></td>
-<td>yes</td>
-<td>5 GB</td>
-<td>75</td>
-<td>1 GB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>22.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XS Medium Space</span></td>
-<td>yes</td>
-<td>10 GB</td>
-<td>75</td>
-<td>1 GB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>24.50 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XS Big Space</span></td>
-<td>yes</td>
-<td>15 GB</td>
-<td>75</td>
-<td>1 GB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>27.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">S Small Space</span></td>
-<td>yes</td>
-<td>10 GB</td>
-<td>125</td>
-<td>2 GB</td>
-<td>Dedicated</td>
-<td>2</td>
-<td>44.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">S Medium Space</span></td>
-<td>yes</td>
-<td>15 GB</td>
-<td>125</td>
-<td>2 GB</td>
-<td>Dedicated</td>
-<td>2</td>
-<td>46.50 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">S Big Space</span></td>
-<td>yes</td>
-<td>20 GB</td>
-<td>125</td>
-<td>2 GB</td>
-<td>Dedicated</td>
-<td>2</td>
-<td>49.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">M Small Space</span></td>
-<td>yes</td>
-<td>20 GB</td>
-<td>250</td>
-<td>4 GB</td>
-<td>Dedicated</td>
-<td>4</td>
-<td>103.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">M Medium Space</span></td>
-<td>yes</td>
-<td>40 GB</td>
-<td>250</td>
-<td>4 GB</td>
-<td>Dedicated</td>
-<td>4</td>
-<td>113.60 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">M Big Space</span></td>
-<td>yes</td>
-<td>80 GB</td>
-<td>250</td>
-<td>4 GB</td>
-<td>Dedicated</td>
-<td>4</td>
-<td>133.60 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">L Small Space</span></td>
-<td>yes</td>
-<td>40 GB</td>
-<td>500</td>
-<td>8 GB</td>
-<td>Dedicated</td>
-<td>6</td>
-<td>207.20 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">L Medium Space</span></td>
-<td>yes</td>
-<td>80 GB</td>
-<td>500</td>
-<td>8 GB</td>
-<td>Dedicated</td>
-<td>6</td>
-<td>227.20 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">L Big Space</span></td>
-<td>yes</td>
-<td>120 GB</td>
-<td>500</td>
-<td>8 GB</td>
-<td>Dedicated</td>
-<td>6</td>
-<td>247.20 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XL Small Space</span></td>
-<td>yes</td>
-<td>80 GB</td>
-<td>750</td>
-<td>16 GB</td>
-<td>Dedicated</td>
-<td>8</td>
-<td>414.40 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XL Medium Space</span></td>
-<td>yes</td>
-<td>160 GB</td>
-<td>750</td>
-<td>16 GB</td>
-<td>Dedicated</td>
-<td>8</td>
-<td>454.40 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XL Big Space</span></td>
-<td>yes</td>
-<td>320 GB</td>
-<td>750</td>
-<td>16 GB</td>
-<td>Dedicated</td>
-<td>8</td>
-<td>534.40 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXL Small Space</span></td>
-<td>yes</td>
-<td>160 GB</td>
-<td>900</td>
-<td>32 GB</td>
-<td>Dedicated</td>
-<td>10</td>
-<td>1022.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXL Medium Space</span></td>
-<td>yes</td>
-<td>320 GB</td>
-<td>900</td>
-<td>32 GB</td>
-<td>Dedicated</td>
-<td>10</td>
-<td>1134.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXL Big Space</span></td>
-<td>yes</td>
-<td>640 GB</td>
-<td>900</td>
-<td>32 GB</td>
-<td>Dedicated</td>
-<td>10</td>
-<td>1358.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXL Huge Space</span></td>
-<td>yes</td>
-<td>960 GB</td>
-<td>900</td>
-<td>32 GB</td>
-<td>Dedicated</td>
-<td>10</td>
-<td>1582.00 €</td>
-</tr>
+<table class="table table-bordered table-striped dataTable">
+  <caption>MySQL pricing plans</caption>
+  <tr>
+    <th>Name</th>
+    <th>DB size</th>
+    <th>Conn. limit</th>
+    <th>Memory</th>
+    <th>Type</th>
+    <th>VCPUS</th>
+    <th>Price / Month</th>
+    <th>Logs & Metrics</th>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">DEV</span>
+    </td>
+    <td>10 MB</td>
+    <td>5</td>
+    <td>Shared</td>
+    <td>Shared</td>
+    <td>Shared</td>
+    <td>Free</td>
+    <td>No</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XXS Small Space</span>
+    </td>
+    <td>512 MB</td>
+    <td>15</td>
+    <td>512 MB</td>
+    <td>Dedicated</td>
+    <td>1</td>
+    <td>5.00 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XXS Medium Space</span>
+    </td>
+    <td>1 GB</td>
+    <td>15</td>
+    <td>512 MB</td>
+    <td>Dedicated</td>
+    <td>1</td>
+    <td>5.90 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XXS Big Space</span>
+    </td>
+    <td>2 GB</td>
+    <td>15</td>
+    <td>512 MB</td>
+    <td>Dedicated</td>
+    <td>1</td>
+    <td>6.80 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XS Tiny Space</span>
+    </td>
+    <td>2 GB</td>
+    <td>75</td>
+    <td>1 GB</td>
+    <td>Dedicated</td>
+    <td>1</td>
+    <td>13.00 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XS Small Space</span>
+    </td>
+    <td>5 GB</td>
+    <td>75</td>
+    <td>1 GB</td>
+    <td>Dedicated</td>
+    <td>1</td>
+    <td>22.00 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XS Medium Space</span>
+    </td>
+    <td>10 GB</td>
+    <td>75</td>
+    <td>1 GB</td>
+    <td>Dedicated</td>
+    <td>1</td>
+    <td>24.50 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XS Big Space</span>
+    </td>
+    <td>15 GB</td>
+    <td>75</td>
+    <td>1 GB</td>
+    <td>Dedicated</td>
+    <td>1</td>
+    <td>27.00 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">S Small Space</span>
+    </td>
+    <td>10 GB</td>
+    <td>125</td>
+    <td>2 GB</td>
+    <td>Dedicated</td>
+    <td>2</td>
+    <td>44.00 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">S Medium Space</span>
+    </td>
+    <td>15 GB</td>
+    <td>125</td>
+    <td>2 GB</td>
+    <td>Dedicated</td>
+    <td>2</td>
+    <td>46.50 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">S Big Space</span>
+    </td>
+    <td>20 GB</td>
+    <td>125</td>
+    <td>2 GB</td>
+    <td>Dedicated</td>
+    <td>2</td>
+    <td>49.00 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">M Small Space</span>
+    </td>
+    <td>20 GB</td>
+    <td>250</td>
+    <td>4 GB</td>
+    <td>Dedicated</td>
+    <td>4</td>
+    <td>103.00 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">M Medium Space</span>
+    </td>
+    <td>40 GB</td>
+    <td>250</td>
+    <td>4 GB</td>
+    <td>Dedicated</td>
+    <td>4</td>
+    <td>113.60 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">M Big Space</span>
+    </td>
+    <td>80 GB</td>
+    <td>250</td>
+    <td>4 GB</td>
+    <td>Dedicated</td>
+    <td>4</td>
+    <td>133.60 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">L Small Space</span>
+    </td>
+    <td>40 GB</td>
+    <td>500</td>
+    <td>8 GB</td>
+    <td>Dedicated</td>
+    <td>6</td>
+    <td>207.20 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">L Medium Space</span>
+    </td>
+    <td>80 GB</td>
+    <td>500</td>
+    <td>8 GB</td>
+    <td>Dedicated</td>
+    <td>6</td>
+    <td>227.20 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">L Big Space</span>
+    </td>
+    <td>120 GB</td>
+    <td>500</td>
+    <td>8 GB</td>
+    <td>Dedicated</td>
+    <td>6</td>
+    <td>247.20 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XL Small Space</span>
+    </td>
+    <td>80 GB</td>
+    <td>750</td>
+    <td>16 GB</td>
+    <td>Dedicated</td>
+    <td>8</td>
+    <td>414.40 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XL Medium Space</span>
+    </td>
+    <td>160 GB</td>
+    <td>750</td>
+    <td>16 GB</td>
+    <td>Dedicated</td>
+    <td>8</td>
+    <td>454.40 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XL Big Space</span>
+    </td>
+    <td>320 GB</td>
+    <td>750</td>
+    <td>16 GB</td>
+    <td>Dedicated</td>
+    <td>8</td>
+    <td>534.40 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XXL Small Space</span>
+    </td>
+    <td>160 GB</td>
+    <td>900</td>
+    <td>32 GB</td>
+    <td>Dedicated</td>
+    <td>10</td>
+    <td>1022.00 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XXL Medium Space</span>
+    </td>
+    <td>320 GB</td>
+    <td>900</td>
+    <td>32 GB</td>
+    <td>Dedicated</td>
+    <td>10</td>
+    <td>1134.00 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XXL Big Space</span>
+    </td>
+    <td>640 GB</td>
+    <td>900</td>
+    <td>32 GB</td>
+    <td>Dedicated</td>
+    <td>10</td>
+    <td>1358.00 €</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <td class="cc-col__price">
+      <span class="label cc-label__price label-info">XXL Huge Space</span>
+    </td>
+    <td>960 GB</td>
+    <td>900</td>
+    <td>32 GB</td>
+    <td>Dedicated</td>
+    <td>10</td>
+    <td>1582.00 €</td>
+    <td>Yes</td>
+  </tr>
 </table>
 
 {{< readfile "/content/partials/db-backup.md" >}}

--- a/deploy/addon/postgresql.md
+++ b/deploy/addon/postgresql.md
@@ -19,302 +19,359 @@ and on standards-compliance.
 
 The version currently installed by the add-on is :
 
-- on shared plans (DEV) : PostgreSQL 11.1
-- on newly created dedicated databases (plans XS Small Space and above) : PostgreSQL 9.6, 10, 11, 12, 13
+- on shared plan (DEV) : 11
+- on dedicated databases (XXS Small Space and above) : 9.6, 10, 11, 12, 13
 
 ## PostgreSQL plans
 
-<table class="table table-bordered table-striped dataTable"><caption>PostgreSQL pricing plans</caption>
-<tr>
-<th>Name</th>
-<th>Logs</th>
-<th>DB size</th>
-<th>Conn. limit</th>
-<th>Memory</th>
-<th>Type</th>
-<th>VCPUS</th>
-<th>Price /mo</th>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">DEV</span></td>
-<td>no</td>
-<td>256 MB</td>
-<td>5</td>
-<td>Shared</td>
-<td>Shared</td>
-<td>Shared</td>
-<td>Free</td>
-</tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXS Small Space</span></td>
-<td>yes</td>
-<td>1 GB</td>
-<td>45</td>
-<td>512 MB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>5.25 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXS Medium Space</span></td>
-<td>yes</td>
-<td>2 GB</td>
-<td>45</td>
-<td>512 MB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>6.80 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXS Big Space</span></td>
-<td>yes</td>
-<td>3 GB</td>
-<td>45</td>
-<td>512 MB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>7.70 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XS Tiny Space</span></td>
-<td>yes</td>
-<td>2 GB</td>
-<td>75</td>
-<td>1 GB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>13.00 €</td>
-</tr>
-<tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XS Small Space</span></td>
-<td>yes</td>
-<td>5 GB</td>
-<td>75</td>
-<td>1 GB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>17.50 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XS Medium Space</span></td>
-<td>yes</td>
-<td>10 GB</td>
-<td>75</td>
-<td>1 GB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>20.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XS Big Space</span></td>
-<td>yes</td>
-<td>15 GB</td>
-<td>75</td>
-<td>1 GB</td>
-<td>Dedicated</td>
-<td>1</td>
-<td>30.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">S Small Space</span></td>
-<td>yes</td>
-<td>10 GB</td>
-<td>125</td>
-<td>2 GB</td>
-<td>Dedicated</td>
-<td>2</td>
-<td>35.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">S Medium Space</span></td>
-<td>yes</td>
-<td>15 GB</td>
-<td>125</td>
-<td>2 GB</td>
-<td>Dedicated</td>
-<td>2</td>
-<td>37.50 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">S Big Space</span></td>
-<td>yes</td>
-<td>20 GB</td>
-<td>125</td>
-<td>2 GB</td>
-<td>Dedicated</td>
-<td>2</td>
-<td>40.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">S Huge Space</span></td>
-<td>yes</td>
-<td>50 GB</td>
-<td>125</td>
-<td>2 GB</td>
-<td>Dedicated</td>
-<td>2</td>
-<td>55.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">M Small Space</span></td>
-<td>yes</td>
-<td>20 GB</td>
-<td>250</td>
-<td>4 GB</td>
-<td>Dedicated</td>
-<td>4</td>
-<td>82.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">M Medium Space</span></td>
-<td>yes</td>
-<td>40 GB</td>
-<td>250</td>
-<td>4 GB</td>
-<td>Dedicated</td>
-<td>4</td>
-<td>92.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">M Big Space</span></td>
-<td>yes</td>
-<td>80 GB</td>
-<td>250</td>
-<td>4 GB</td>
-<td>Dedicated</td>
-<td>4</td>
-<td>112.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">L Small Space</span></td>
-<td>yes</td>
-<td>40 GB</td>
-<td>500</td>
-<td>8 GB</td>
-<td>Dedicated</td>
-<td>6</td>
-<td>164.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">L Medium Space</span></td>
-<td>yes</td>
-<td>80 GB</td>
-<td>500</td>
-<td>8 GB</td>
-<td>Dedicated</td>
-<td>6</td>
-<td>184.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">L Big Space</span></td>
-<td>yes</td>
-<td>120 GB</td>
-<td>500</td>
-<td>8 GB</td>
-<td>Dedicated</td>
-<td>6</td>
-<td>204.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XL Small Space</span></td>
-<td>yes</td>
-<td>80 GB</td>
-<td>750</td>
-<td>16 GB</td>
-<td>Dedicated</td>
-<td>8</td>
-<td>328.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XL Medium Space</span></td>
-<td>yes</td>
-<td>160 GB</td>
-<td>750</td>
-<td>16 GB</td>
-<td>Dedicated</td>
-<td>8</td>
-<td>368.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XL Big Space</span></td>
-<td>yes</td>
-<td>320 GB</td>
-<td>750</td>
-<td>16 GB</td>
-<td>Dedicated</td>
-<td>8</td>
-<td>448.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXL Small Space</span></td>
-<td>yes</td>
-<td>160 GB</td>
-<td>900</td>
-<td>32 GB</td>
-<td>Dedicated</td>
-<td>10</td>
-<td>796.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXL Medium Space</span></td>
-<td>yes</td>
-<td>320 GB</td>
-<td>900</td>
-<td>32 GB</td>
-<td>Dedicated</td>
-<td>10</td>
-<td>892.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXL Big Space</span></td>
-<td>yes</td>
-<td>640 GB</td>
-<td>900</td>
-<td>32 GB</td>
-<td>Dedicated</td>
-<td>10</td>
-<td>1084.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXL Huge Space</span></td>
-<td>yes</td>
-<td>960 GB</td>
-<td>900</td>
-<td>32 GB</td>
-<td>Dedicated</td>
-<td>10</td>
-<td>1276.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXXL Small Space</span></td>
-<td>yes</td>
-<td>640 GB</td>
-<td>1200</td>
-<td>64 GB</td>
-<td>Dedicated</td>
-<td>12</td>
-<td>1598.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXXL Medium Space</span></td>
-<td>yes</td>
-<td>960 GB</td>
-<td>1200</td>
-<td>64 GB</td>
-<td>Dedicated</td>
-<td>12</td>
-<td>1822.00 €</td>
-</tr>
-<tr>
-<td class="cc-col__price"><span class="label cc-label__price label-info">XXXL Big Space</span></td>
-<td>yes</td>
-<td>1200 GB</td>
-<td>1200</td>
-<td>64 GB</td>
-<td>Dedicated</td>
-<td>12</td>
-<td>1990.00 €</td>
-</tr>
+<table class="table table-bordered table-striped dataTable">
+    <caption>PostgreSQL pricing plans</caption>
+    <tr>
+        <th>Name</th>
+        <th>DB size</th>
+        <th>Conn. limit</th>
+        <th>Memory</th>
+        <th>Type</th>
+        <th>VCPUS</th>
+        <th>Price / Month</th>
+        <th>Logs & Metrics</th>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">DEV</span>
+        </td>
+        <td>256 MB</td>
+        <td>5</td>
+        <td>Shared</td>
+        <td>Shared</td>
+        <td>Shared</td>
+        <td>Free</td>
+        <td>No</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XXS Small Space</span>
+        </td>
+        <td>1 GB</td>
+        <td>45</td>
+        <td>512 MB</td>
+        <td>Dedicated</td>
+        <td>1</td>
+        <td>5.25 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XXS Medium Space</span>
+        </td>
+        <td>2 GB</td>
+        <td>45</td>
+        <td>512 MB</td>
+        <td>Dedicated</td>
+        <td>1</td>
+        <td>6.80 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XXS Big Space</span>
+        </td>
+        <td>3 GB</td>
+        <td>45</td>
+        <td>512 MB</td>
+        <td>Dedicated</td>
+        <td>1</td>
+        <td>7.70 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XS Tiny Space</span>
+        </td>
+        <td>2 GB</td>
+        <td>75</td>
+        <td>1 GB</td>
+        <td>Dedicated</td>
+        <td>1</td>
+        <td>13.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XS Small Space</span>
+        </td>
+        <td>5 GB</td>
+        <td>75</td>
+        <td>1 GB</td>
+        <td>Dedicated</td>
+        <td>1</td>
+        <td>17.50 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XS Medium Space</span>
+        </td>
+        <td>10 GB</td>
+        <td>75</td>
+        <td>1 GB</td>
+        <td>Dedicated</td>
+        <td>1</td>
+        <td>20.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XS Big Space</span>
+        </td>
+        <td>15 GB</td>
+        <td>75</td>
+        <td>1 GB</td>
+        <td>Dedicated</td>
+        <td>1</td>
+        <td>30.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">S Small Space</span>
+        </td>
+        <td>10 GB</td>
+        <td>125</td>
+        <td>2 GB</td>
+        <td>Dedicated</td>
+        <td>2</td>
+        <td>35.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">S Medium Space</span>
+        </td>
+        <td>15 GB</td>
+        <td>125</td>
+        <td>2 GB</td>
+        <td>Dedicated</td>
+        <td>2</td>
+        <td>37.50 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">S Big Space</span>
+        </td>
+        <td>20 GB</td>
+        <td>125</td>
+        <td>2 GB</td>
+        <td>Dedicated</td>
+        <td>2</td>
+        <td>40.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">S Huge Space</span>
+        </td>
+        <td>50 GB</td>
+        <td>125</td>
+        <td>2 GB</td>
+        <td>Dedicated</td>
+        <td>2</td>
+        <td>55.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">M Small Space</span>
+        </td>
+        <td>20 GB</td>
+        <td>250</td>
+        <td>4 GB</td>
+        <td>Dedicated</td>
+        <td>4</td>
+        <td>82.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">M Medium Space</span>
+        </td>
+        <td>40 GB</td>
+        <td>250</td>
+        <td>4 GB</td>
+        <td>Dedicated</td>
+        <td>4</td>
+        <td>92.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">M Big Space</span>
+        </td>
+        <td>80 GB</td>
+        <td>250</td>
+        <td>4 GB</td>
+        <td>Dedicated</td>
+        <td>4</td>
+        <td>112.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">L Small Space</span>
+        </td>
+        <td>40 GB</td>
+        <td>500</td>
+        <td>8 GB</td>
+        <td>Dedicated</td>
+        <td>6</td>
+        <td>164.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">L Medium Space</span>
+        </td>
+        <td>80 GB</td>
+        <td>500</td>
+        <td>8 GB</td>
+        <td>Dedicated</td>
+        <td>6</td>
+        <td>184.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">L Big Space</span>
+        </td>
+        <td>120 GB</td>
+        <td>500</td>
+        <td>8 GB</td>
+        <td>Dedicated</td>
+        <td>6</td>
+        <td>204.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XL Small Space</span>
+        </td>
+        <td>80 GB</td>
+        <td>750</td>
+        <td>16 GB</td>
+        <td>Dedicated</td>
+        <td>8</td>
+        <td>328.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XL Medium Space</span>
+        </td>
+        <td>160 GB</td>
+        <td>750</td>
+        <td>16 GB</td>
+        <td>Dedicated</td>
+        <td>8</td>
+        <td>368.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XL Big Space</span>
+        </td>
+        <td>320 GB</td>
+        <td>750</td>
+        <td>16 GB</td>
+        <td>Dedicated</td>
+        <td>8</td>
+        <td>448.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XXL Small Space</span>
+        </td>
+        <td>160 GB</td>
+        <td>900</td>
+        <td>32 GB</td>
+        <td>Dedicated</td>
+        <td>10</td>
+        <td>796.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XXL Medium Space</span>
+        </td>
+        <td>320 GB</td>
+        <td>900</td>
+        <td>32 GB</td>
+        <td>Dedicated</td>
+        <td>10</td>
+        <td>892.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XXL Big Space</span>
+        </td>
+        <td>640 GB</td>
+        <td>900</td>
+        <td>32 GB</td>
+        <td>Dedicated</td>
+        <td>10</td>
+        <td>1084.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XXL Huge Space</span>
+        </td>
+        <td>960 GB</td>
+        <td>900</td>
+        <td>32 GB</td>
+        <td>Dedicated</td>
+        <td>10</td>
+        <td>1276.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XXXL Small Space</span>
+        </td>
+        <td>640 GB</td>
+        <td>1200</td>
+        <td>64 GB</td>
+        <td>Dedicated</td>
+        <td>12</td>
+        <td>1598.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XXXL Medium Space</span>
+        </td>
+        <td>960 GB</td>
+        <td>1200</td>
+        <td>64 GB</td>
+        <td>Dedicated</td>
+        <td>12</td>
+        <td>1822.00 €</td>
+        <td>Yes</td>
+    </tr>
+    <tr>
+        <td class="cc-col__price">
+            <span class="label cc-label__price label-info">XXXL Big Space</span>
+        </td>
+        <td>1200 GB</td>
+        <td>1200</td>
+        <td>64 GB</td>
+        <td>Dedicated</td>
+        <td>12</td>
+        <td>1990.00 €</td>
+        <td>Yes</td>
+    </tr>
 </table>
 
 {{< readfile "/content/partials/db-backup.md" >}}


### PR DESCRIPTION
I updated PostgreSQL, MySQL and MongoDB addon pricing tables, the same information with logs & metrics availability is now shown and situated in the same place, just after the version section.

MongoDB pricing table was also outdated.