### PR TITLE
Help text when logs drain is disabled

### DIFF
--- a/administrate/log-management.md
+++ b/administrate/log-management.md
@@ -19,51 +19,65 @@ Log management is currently only available through our API and [clever-tools]({{
 
 You can see logs with the command down below.
 
-    clever logs
+```bash
+clever logs
+```
 
 You can also add a flag `--before` or `--after` followed by a date (ISO8601 format).
 
-    # Here is an example
-    clever logs --before 2016-08-11T14:54:33.971Z
+```bash
+# Here is an example
+clever logs --before 2016-08-11T14:54:33.971Z
+```
 
-### Logs drains: exporting logs to an external tools
+## Exporting logs to an external tools
 
 You can use the logs drains to send your application's logs to an external server with the following command.
 
-
-    clever drain create [--alias <alias>] <DRAIN-TYPE> <DRAIN-URL> [--username <username>] [--password <password>]
+```bash
+clever drain create [--alias <alias>] <DRAIN-TYPE> <DRAIN-URL> [--username <username>] [--password <password>]
+```
 
 Where `DRAIN-TYPE` is one of:
 
- - `TCPSyslog`: for TCP syslog endpoint;
- - `UDPSyslog`: for UDP syslog endpoint;
- - `HTTP`: for TCP syslog endpoint (note that this endpoint has optional username/password parameters as HTTP Basic Authentication);
- - `ElasticSearch`: for ElasticSearch endpoint (note that this endpoint requires username/password parameters as HTTP Basic Authentication);
- - `DatadogHTTP`: for Datadog endpoint (note that this endpoint needs your Datadog API Key).
+- `TCPSyslog`: for TCP syslog endpoint;
+- `UDPSyslog`: for UDP syslog endpoint;
+- `HTTP`: for TCP syslog endpoint (note that this endpoint has optional username/password parameters as HTTP Basic Authentication);
+- `ElasticSearch`: for ElasticSearch endpoint (note that this endpoint requires username/password parameters as HTTP Basic Authentication);
+- `DatadogHTTP`: for Datadog endpoint (note that this endpoint needs your Datadog API Key).
 
 You can list the currently activated drains with this command.
 
-    clever drain [--alias <alias>]
+```bash
+clever drain [--alias <alias>]
+```
 
 And remove them if needed
 
-    clever drain remove [--alias <alias>] <DRAIN-ID>
+```bash
+clever drain remove [--alias <alias>] <DRAIN-ID>
+```
 
-#### ElasticSearch logs drains
+### ElasticSearch
 
 ElasticSearch drains use the Elastic bulk API. To match this endpoint, specify `/_bulk` at the end of your ElasticSearch endpoint.
 
 Each day, we will create an index `logstash-<yyyy-MM-dd>` and push logs to it.
 
-#### Datadog logs drains
+### Datadog
 
 Datadog has two zones, EU and COM. An account on one zone is not available on the other, make sure to target the good EU or COM intake endpoint.
 
-To create a [Datadog](https://docs.datadoghq.com/api/?lang=python#send-logs-over-http) drain, you just need to use:
+To create a [Datadog](https://docs.datadoghq.com/fr/api/latest/logs/#send-logs) drain, you just need to use:
 
-    clever drain create DatadogHTTP "https://http-intake.logs.datadoghq.com/v1/input/<API_KEY>?ddsource=clevercloud&service=<SERVICE>&host=<HOST>"
+```bash
+clever drain create DatadogHTTP "https://http-intake.logs.datadoghq.com/v1/input/<API_KEY>?ddsource=clevercloud&service=<SERVICE>&hostname=<HOST>"
+```
 
-#### Logs extended storage
+## Logs extended storage
 
-Each organisations or personal space has `Logs extended storage` Cellar addon. This addon will be used to store your applications/addons logs when the hot retention is reached when the feature will be available.
-Then, the most aged logs will be pushed to `Logs extended storage` as cold storage. The retention for cold storage will be user defined via a new log management interface.
+Each organisations or personal space has a `Logs extended storage` Cellar addon.
+This addon will be used to store your applications/addons logs when the hot retention is reached when the feature will be available.
+
+The most aged logs will be pushed to `Logs extended storage` as cold storage.
+The retention for cold storage will be user defined via a new log management interface.

--- a/administrate/log-management.md
+++ b/administrate/log-management.md
@@ -58,6 +58,8 @@ And remove them if needed
 clever drain remove [--alias <alias>] <DRAIN-ID>
 ```
 
+If the status of your drain is shown as `DISABLED` without you disabling it, it may be because we  have not been able to send your logs to your drain endpoint or because the requests timed out after 25 seconds.
+
 ### ElasticSearch
 
 ElasticSearch drains use the Elastic bulk API. To match this endpoint, specify `/_bulk` at the end of your ElasticSearch endpoint.


### PR DESCRIPTION
A user can disable a logs drain himself but sometimes our system disable it if the drain endpoint does not answer or times out.

So I added a little text to help the user about that case.