### PR TITLE
Install composer development deps from env

### DIFF
--- a/partials/language-specific-deploy/php.md
+++ b/partials/language-specific-deploy/php.md
@@ -238,16 +238,14 @@ We support Composer build out of the box. You just need to provide a `composer.j
 You can also set the `CC_COMPOSER_VERSION` to `1` or `2` to select the composer version to use.
 
 {{< alert "info" "Note:" >}}
-    <p>If you encounter any issues, add your own `composer.phar` file in the root of your repository which will override the version we use.</p>
+    If you encounter any issues, add your own `composer.phar` file in the root of your repository which will override the version we use.
 {{< /alert >}}
 
-You can perform your own `composer.phar install` by using the [Post Build hook]({{< ref "develop/build-hooks.md#post-build-cc_post_build_hook" >}}) if for example you need to install dev dependencies.
-
-If you need to install development dependencies automatically, please let us know by opening a support ticket. This feature may be implemented using an environment variable in the future if this is often asked.
+You can perform your own `composer.phar install` by using the [Post Build hook]({{< ref "develop/build-hooks.md#post-build-cc_post_build_hook" >}}).
 
 Example of a `composer.json` file:
 
-```javascript
+```json
 {
    "require": {
       "laravel/framework": "4.1.*",
@@ -280,6 +278,12 @@ Example of a `composer.json` file:
 ```
 
 Example of a minimalist PHP application using composer and custom scripts: [php-composer-demo](https://GitHub.com/CleverCloud/php-composer-demo)
+
+## Development Dependencies
+
+Development dependencies will not be automatically installed during the deployment. You can control their installation by using the `CC_PHP_DEV_DEPENDENCIES` environment variable which takes `install` value.
+
+Any other value than `install` will prevent developement dependencies from being installed.
 
 ### GitHub rate limit
 

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -147,6 +147,7 @@ So you can alter the build&start process for your application.
  |MEMORY_LIMIT | Change the default memory limit |  |  |
  |CC_PHP_VERSION | Choose your PHP version between `5.6`, `7.2`, `7.3`, `7.4` and `8.0` | `7` |  |
  |CC_COMPOSER_VERSION | Choose your composer version between `1` and `2` | `2` |  |
+ |[CC_PHP_DEV_DEPENDENCIES]({{< ref "deploy/application/php/php-apps.md#development-dependencies" >}}) | Control if development dependencies are installed or not. Values are either `install` or `ignore` |  |  |
  |[SESSION_TYPE]({{< ref "deploy/application/php/php-apps.md#use-redis-to-store-php-sessions" >}}) | Choose `redis` to use it as session store |  |  |
  |SOCKSIFY_EVERYTHING |  |  |  |
  |USE_SOCKS |  | `false` |  |


### PR DESCRIPTION
It will now be possible to install development dependencies with composer from the environment variable `CC_PHP_DEV_DEPENDENCIES`.