### PR TITLE
Define manage.py tasks from env

### DIFF
--- a/deploy/application/python/tutorials/python-django-sample.md
+++ b/deploy/application/python/tutorials/python-django-sample.md
@@ -22,6 +22,7 @@ The application is a very basic one. More information about the application:
 {{< readfile "/content/partials/set-env-vars.md" >}}
 
 ## Configure your Django application
+
 ### My application does not exists already
 
 If you want to test easily a Django deployment on Clever Cloud, just clone the [GitHub repo](https://GitHub.com/CleverCloud/django-example) and jump to [My application already exists](#my-application-already-exists)
@@ -39,6 +40,20 @@ If you want to test easily a Django deployment on Clever Cloud, just clone the [
 You can find a lot more configuration options such as choosing python version and more on our dedicated [python documentation]({{< ref "/deploy/application/python/python_apps.md" >}})
 
 {{< readfile "/content/partials/new-relic.md" >}}
+
+### Manage.py tasks
+
+Clever Cloud supports execution of multiple [manage.py](https://docs.djangoproject.com/fr/3.2/ref/django-admin/) tasks.
+
+The tasks are launched after the dependencies from `requirements.txt` have been installed.
+
+You can declare the `manage.py` tasks with the [environment variable](#setting-up-environment-variables-on-clever-cloud) `CC_PYTHON_MANAGE_TASKS="migrate"`.
+
+Values must be separated by a comma:
+
+```bash
+CC_PYTHON_MANAGE_TASKS="migrate, assets:precompile"
+```
 
 {{< readfile "/content/partials/env-injection.md" >}}
 

--- a/partials/language-specific-deploy/python.md
+++ b/partials/language-specific-deploy/python.md
@@ -56,18 +56,6 @@ The goal will be launched after the dependencies from `requirements.txt` have be
 
 To execute a goal, you can define the [environment variable](#setting-up-environment-variables-on-clever-cloud) `PYTHON_SETUP_PY_GOAL="<your goal>"`.
 
-### Manage.py tasks
-
-Clever Cloud supports execution of multiple `manage.py` tasks. The tasks are launched after the dependencies from `requirements.txt` have been installed.
-
-You can declare the `manage.py` tasks with the [environment variable](#setting-up-environment-variables-on-clever-cloud) `CC_PYTHON_MANAGE_TASKS="migrate"`.
-
-Values must be separated by a comma:
-
-```bash
-CC_PYTHON_MANAGE_TASKS="migrate, assets:precompile"
-```
-
 {{< readfile "/content/partials/env-injection.md" >}}
 
 To access [environment variables](#setting-up-environment-variables-on-clever-cloud) from your code, just get them from the environment with:

--- a/partials/language-specific-deploy/python.md
+++ b/partials/language-specific-deploy/python.md
@@ -56,18 +56,16 @@ The goal will be launched after the dependencies from `requirements.txt` have be
 
 To execute a goal, you can define the [environment variable](#setting-up-environment-variables-on-clever-cloud) `PYTHON_SETUP_PY_GOAL="<your goal>"`.
 
-### Manage.py tasks with clevercloud/python.json
+### Manage.py tasks
 
 Clever Cloud supports execution of multiple `manage.py` tasks. The tasks are launched after the dependencies from `requirements.txt` have been installed.
 
-You can declare the `manage.py` tasks in `./clevercloud/python.json` with the following syntax:
+You can declare the `manage.py` tasks with the [environment variable](#setting-up-environment-variables-on-clever-cloud) `CC_PYTHON_MANAGE_TASKS="migrate"`.
 
-```json
-{
-    "deploy": {
-        "managetasks": [ "migrate" ]
-    }
-}
+Values must be separated by a comma:
+
+```bash
+CC_PYTHON_MANAGE_TASKS="migrate, assets:precompile"
 ```
 
 {{< readfile "/content/partials/env-injection.md" >}}

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -189,6 +189,7 @@ So you can alter the build&start process for your application.
  |CC_PYTHON_CELERY_MODULE | Specify the Celery module you want to start: `mymodule` |  |  |
  |CC_PYTHON_CELERY_USE_BEAT | Set to `true` to activate Beat support |  |  |
  |CC_PYTHON_MODULE | Select which module you want to start: `mymodule:app`. 'mymodule' refers to the path to the folder containing the app object. So a module called 'server.py' in a folder called 'app' would be used here as `app.server:app` |  |  |
+ |CC_PYTHON_MANAGE_TASKS | Comma-separated list of manage tasks |  |  |
  |CC_PYTHON_USE_GEVENT | Set to `true` to enable Gevent |  |  |
  |HARAKIRI | Timeout (in seconds) after which an unresponding process is killed | `180` |  |
  |CC_PYTHON_BACKEND | Choose the Python backend to use between `daphne`, `gunicorn`, `uvicorn` and `uwsgi` | `uwsgi` |  |

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -189,7 +189,7 @@ So you can alter the build&start process for your application.
  |CC_PYTHON_CELERY_MODULE | Specify the Celery module you want to start: `mymodule` |  |  |
  |CC_PYTHON_CELERY_USE_BEAT | Set to `true` to activate Beat support |  |  |
  |CC_PYTHON_MODULE | Select which module you want to start: `mymodule:app`. 'mymodule' refers to the path to the folder containing the app object. So a module called 'server.py' in a folder called 'app' would be used here as `app.server:app` |  |  |
- |CC_PYTHON_MANAGE_TASKS | Comma-separated list of manage tasks |  |  |
+ |[CC_PYTHON_MANAGE_TASKS]({{ < ref "deploy/application/python/tutorials/python-django-sample.md#manage-py-tasks" > }}) | Comma-separated list of Django manage tasks |  |  |
  |CC_PYTHON_USE_GEVENT | Set to `true` to enable Gevent |  |  |
  |HARAKIRI | Timeout (in seconds) after which an unresponding process is killed | `180` |  |
  |CC_PYTHON_BACKEND | Choose the Python backend to use between `daphne`, `gunicorn`, `uvicorn` and `uwsgi` | `uwsgi` |  |


### PR DESCRIPTION
It will now be possible to define manage.py tasks from the environment variable CC_PYTHON_MANAGE_TASKS.