### PR TITLE
Elastic / PHP: add Elastic APM support for PHP

### DIFF
--- a/deploy/addon/elastic.md
+++ b/deploy/addon/elastic.md
@@ -46,6 +46,7 @@ Currently, APM agents are available in the following languages:
 - [Go](https://www.elastic.co/guide/en/apm/agent/go/1.x/introduction.html)
 - [Java](https://www.elastic.co/guide/en/apm/agent/java/1.x/intro.html)
 - [Node.js](https://www.elastic.co/guide/en/apm/agent/nodejs/2.x/intro.html)
+- [PHP](https://www.elastic.co/guide/en/apm/agent/php/current/index.html)
 - [Python](https://www.elastic.co/guide/en/apm/agent/python/5.x/getting-started.html)
 - [Ruby](https://www.elastic.co/guide/en/apm/agent/ruby/3.x/introduction.html)
 

--- a/partials/language-specific-deploy/php.md
+++ b/partials/language-specific-deploy/php.md
@@ -388,6 +388,12 @@ Some extensions need to be enabled explicitly. To enable these extensions, you'l
 
     Couchbase is a document database with a SQL-based query language that is engineered to deliver performance at scale.
 
+* Elastic APM Agent: set `ENABLE_ELASTIC_APM_AGENT` to `true` (default if `ELASTIC_APM_SERVER_URL` is defined).
+
+    Elastic APM agent is Elastic's APM agent extension for PHP. The PHP agent enables you to trace the execution of operations
+    in your application, sending performance metrics and errors to the Elastic APM server.
+    **Warning**: This extension is available starting PHP 7.2.
+
 * IonCube: set `ENABLE_IONCUBE` to `true`.
 
     IonCube is a tool to obfuscate PHP code. It's often used by paying Prestashop and WordPress plugins.

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -345,7 +345,7 @@ So you can alter the build&start process for your application.
  {{<table "table table- bordered" "text-align:center" >}}
  | <center>Name</center> | <center>Description</center> | <center>Default value</center> | <center>Read Only</center> |
  |-----------------------|------------------------------|--------------------------------|--------------------------------|
- |ELASTIC_APM_SERVER_URLS | URI to connect APM Server | Generated upon creation | X  |
+ |ELASTIC_APM_SERVER_URL | URI to connect APM Server | Generated upon creation | X  |
  |ES_ADDON_APM_HOST | APM Server hostname | Generated upon creation | X  |
  |ES_ADDON_APM_AUTH_TOKEN | Authentication token to send metrics to APM Server | Generated upon creation | X  |
  |ELASTIC_APM_SECRET_TOKEN | Authentication token to send metrics to APM Server | Generated upon creation | X  |

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -145,6 +145,7 @@ So you can alter the build&start process for your application.
  |CC_LDAP_CA_CERT |  |  |  |
  |CC_WEBROOT | Define the `DocumentRoot` of your project | . |  |
  |LDAPTLS_CACERT |  |  |  |
+ |ENABLE_ELASTIC_APM_AGENT | Elastic APM Agent for PHP | `true` if `ELASTIC_APM_SERVER_URL` is defined, `false` otherwise | |
  |ENABLE_REDIS |  | `false` |  |
  |HTTP_TIMEOUT | Define a custom HTTP timeout | `180` |  |
  |MAX_INPUT_VARS |  |  |  |


### PR DESCRIPTION
This introduces Elastic APM support for PHP.

It also replace the `ELASTIC_APM_SERVER_URLS` environment variable by `ELASTIC_APM_SERVER_URL`. 
```
    ELASTIC_APM_SERVER_URLS is only used by the Java APM agent, which also
    supports ELASTIC_APM_SERVER_URL. So ELASTIC_APM_SERVER_URLS is now the
    one to be automatically defined and ELASTIC_APM_SERVER_URLS stays
    supported by the Java APM product
```