### PR TITLE
Add missing env var `CC_RUN_COMMAND` for Rust and .Net

### DIFF
--- a/deploy/application/dotnet/dotnet.md
+++ b/deploy/application/dotnet/dotnet.md
@@ -104,6 +104,12 @@ restart --without-cache` from [CLI](https://github.com/CleverCloud/clever-tools)
 CC_DOTNET_PROFILE=Debug
 ```
 
+### Custom run command
+
+If you need to run a custom command (or just pass options to the program), you can specify it through the `CC_RUN_COMMAND` [environment variable](#setting-up-environment-variables-on-clever-cloud).
+
+For instance, you can have `CC_RUN_COMMAND=./bin/Release/net5.0/myapp <options>`.
+
 ### Private dependencies
 
 Support for private dependencies will be available soon.

--- a/partials/language-specific-deploy/rust.md
+++ b/partials/language-specific-deploy/rust.md
@@ -33,6 +33,12 @@ fn main() {
 If your `Cargo.toml` defines multiple targets, you must specify the one you want to run, with the `CC_RUST_BIN` environment variable.
 If `CC_RUST_BIN` is specified, then the executable produced by this target is used to start the application.
 
+### Custom run command
+
+If you need to run a custom command (or just pass options to the program), you can specify it through the `CC_RUN_COMMAND` [environment variable](#setting-up-environment-variables-on-clever-cloud).
+
+For instance, you can have `CC_RUN_COMMAND=./target/release/myapp <options>`.
+
 ### Dependencies
 
 Make sure to list all your dependencies in `Cargo.toml`. For the example above, you need:

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -248,6 +248,7 @@ So you can alter the build&start process for your application.
  |CC_RUST_BIN | The name of the binary to launch once built |  |  |
  |CC_RUSTUP_CHANNEL | The rust channel to use. Use a specific channel version with `stable`, `beta`, `nightly` or a specific version like `1.13.0`  | `stable` |  |
  |CC_RUST_FEATURES | The list of features to enable |  |  |
+ |CC_RUN_COMMAND | Custom command to run your application. |  |  |
  {{< /table >}}
 
 ## .NET
@@ -261,6 +262,7 @@ So you can alter the build&start process for your application.
  |CC_DOTNET_PROJ | The name of your project file to use for the build, without the .csproj / .fsproj / .vbproj extension. |  |  |
  |CC_DOTNET_TFM | Compiles for a specific framework. The framework must be defined in the project file. Example : `netcoreapp3.1` |  |  |
  |CC_DOTNET_PROFILE | Override the build configuration settings in your project. | Release |  |
+ |CC_RUN_COMMAND | Custom command to run your application. |  |  |
  {{< /table >}}
 
 ## [Elixir]({{< ref "deploy/application/elixir/elixir.md" >}})


### PR DESCRIPTION
Closes #618.