### PR TITLE
Add wildfly 23

### DIFF
--- a/deploy/application/java/java-war.md
+++ b/deploy/application/java/java-war.md
@@ -66,7 +66,7 @@ The supported containers are listed below:
          <td></td>
          <td></td>
          <td></td>
-         <td></td>
+         <td>WildFly 23.0.2 (WILDFLY23)</td>
       </tr>
       <tr>
          <td>Apache Tomcat 7.0 (TOMCAT7)</td>
@@ -334,6 +334,14 @@ Here's the list of the configuration values for the "container" field in `war.js
       <tr>
          <td>WILDFLY9</td>
          <td>Use Wildfly servlet container 9.x (see <a href="https://wildfly.org/">https://wildfly.org/</a>)</td>
+      </tr>
+      <tr>
+         <td>WILDFLY17</td>
+         <td>Use Wildfly servlet container 17.x (see <a href="https://wildfly.org/">https://wildfly.org/</a>)</td>
+      </tr>
+      <tr>
+         <td>WILDFLY23</td>
+         <td>Use Wildfly servlet container 23.x (see <a href="https://wildfly.org/">https://wildfly.org/</a>)</td>
       </tr>
    </tbody>
 </table>

--- a/partials/java-versions.md
+++ b/partials/java-versions.md
@@ -4,7 +4,7 @@ Simply set the environment variable **CC_JAVA_VERSION** to the version you want.
 
 {{< alert "info" "Default version" >}}
     <p>We are using Java version 11 by default.</p>
-    <p>New applications will have the strong <strong>CC_JAVA_VERSION</strong> environment variable set to 11.</p>
+    <p>New applications will have the <strong>CC_JAVA_VERSION</strong> environment variable set to 11.</p>
 {{< /alert >}}
 
 Accepted values are `7`, `8`, `11`, `16` or `graalvm-ce` (for GraalVM 21.0.0.2, based on OpenJDK 11.0).


### PR DESCRIPTION
As of now, Wildfly is offered in the versions 9, 17 and 23 (and possibly 24?). All of those should be documented as options.