### PR TITLE
pulsar: do not use topic list for the moment

### DIFF
--- a/deploy/addon/pulsar.md
+++ b/deploy/addon/pulsar.md
@@ -167,7 +167,7 @@ We advise you to use [`pulsarctl`](https://github.com/streamnative/pulsarctl) pr
 pulsarctl --admin-service-url $ADDON_PULSAR_HTTP_URL \
           --auth-params $ADDON_PULSAR_TOKEN \
           --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken \
-          topics list $ADDON_PULSAR_TENANT/$ADDON_PULSAR_NAMESPACE
+          namespaces topic $ADDON_PULSAR_TENANT/$ADDON_PULSAR_NAMESPACE
 ```
 
 ### Rust example


### PR DESCRIPTION
The /topic endpoint does not support Biscuit at the moment.