### PR TITLE
fix(create-application): add org selection step

### DIFF
--- a/partials/create-application.md
+++ b/partials/create-application.md
@@ -2,11 +2,12 @@
 
 ### via the web console
 
-1. Create a new app by clicking on the **Add an Application** button, in the sidebar.
-2. Select a brand new instance (or a repository from GitHub if your account is linked).
-3. Then select @application-type@ in the platform list.
-4. Configure your scaling options.
-5. Enter your application's name and description and click "Next". You can also select the region you want (North America or Europe).
+1. Select the proper organization you want to add the application to. At this point you should only have the Personal Space, click on the **Me** button in the left sidebar.
+2. Create a new application by clicking on the **Create...** button in the sidebar, then select **an application**.
+3. Select a brand new instance (or a repository from GitHub if your account is linked).
+4. Then select @application-type@ in the platform list.
+5. Configure your scaling options.
+6. Enter your application's name and description and click "Next". You can also select the region you want (North America or Europe).
 
 Refer to the [getting started]({{< ref "/getting-started/" >}}) for more details on application creation via the console.
 


### PR DESCRIPTION
A step is missing when you land in the console to create a new application.