### PR TITLE
Memory usage during building

### DIFF
--- a/partials/language-specific-deploy/docker.md
+++ b/partials/language-specific-deploy/docker.md
@@ -20,7 +20,7 @@ CMD <command to run>
 
 ### Memory usage during building
 
-If the building step of your app crashets because it users more memory that it's available, you'll have to split the building and running steps and enable [Dedicated build instance]({{< ref "administrate/apps-management.md#edit-application-configuration" >}})
+If the building step of your app crashes because it uses more memory that it's available, you'll have to split the building and running steps and enable [Dedicated build instance]({{< ref "administrate/apps-management.md#edit-application-configuration" >}})
 
 ```bash
 # The base image

--- a/partials/language-specific-deploy/docker.md
+++ b/partials/language-specific-deploy/docker.md
@@ -16,6 +16,8 @@ You can virtually put everything you want in your Dockerfile. The only mandatory
 CMD <command to run>
 ```
 
+**command to run**: this is the command that starts your application. Your application **must** listen on port 8080. It can be easier for you to put a script in your docker image and call it with the CMD instruction.
+
 ### Memory usage during building
 
 If the building step of your app crashets because it users more memory that it's available, you'll have to split the building and running steps and enable [Dedicated build instance]({{< ref "administrate/apps-management.md#edit-application-configuration" >}})
@@ -30,8 +32,6 @@ RUN yarn install && yarn build
 # Start the app on a smaller instance (nano)
 CMD yarn start
 ```
-
-**command to run**: this is the command that starts your application. Your application **must** listen on port 8080. It can be easier for you to put a script in your docker image and call it with the CMD instruction.
 
 ### TCP support
 

--- a/partials/language-specific-deploy/docker.md
+++ b/partials/language-specific-deploy/docker.md
@@ -21,10 +21,13 @@ CMD <command to run>
 If the building step of your app crashets because it users more memory that it's available, you'll have to split the building and running steps and enable [Dedicated build instance]({{< ref "administrate/apps-management.md#edit-application-configuration" >}})
 
 ```bash
-# Run the memory intensive build on a M instance
+# The base image
+FROM outlinewiki/outline:version-0.44.0
+
+# Run the memory intensive build on an instance with 4 GB of memory (M)
 RUN yarn install && yarn build
 
-# Start the app on a smaller instance
+# Start the app on a smaller instance (nano)
 CMD yarn start
 ```
 

--- a/partials/language-specific-deploy/docker.md
+++ b/partials/language-specific-deploy/docker.md
@@ -16,6 +16,18 @@ You can virtually put everything you want in your Dockerfile. The only mandatory
 CMD <command to run>
 ```
 
+### Memory usage during building
+
+If the building step of your app crashets because it users more memory that it's available, you'll have to split the building and running steps and enable [Dedicated build instance]({{< ref "administrate/apps-management.md#edit-application-configuration" >}})
+
+```bash
+# Run the memory intensive build on a M instance
+RUN yarn install && yarn build
+
+# Start the app on a smaller instance
+CMD yarn start
+```
+
 **command to run**: this is the command that starts your application. Your application **must** listen on port 8080. It can be easier for you to put a script in your docker image and call it with the CMD instruction.
 
 ### TCP support


### PR DESCRIPTION
I struggled with the “Dedicated build instance” parameter, it didn't worked as expected until I understood this example: https://www.clever-cloud.com/doc/getting-started/by-language/docker/#dockerized-rust-application-deployment