### PR TITLE
Fix location of java configuration files and add alternative with env vars

### DIFF
--- a/deploy/application/java/java-gradle.md
+++ b/deploy/application/java/java-gradle.md
@@ -29,7 +29,7 @@ Note : like other runtimes, Java application need listen on `0.0.0.0:8080`
 ## Configure your Java application
 
 You *must* provide a `clevercloud/gradle.json` file (gradle.json file in
-clevercloud folder which is at the root of you application) that
+clevercloud folder which is at the root of your repository) that
 contains at least the following:
 
 ```json

--- a/deploy/application/java/java-jar.md
+++ b/deploy/application/java/java-jar.md
@@ -26,7 +26,7 @@ Note : like other runtimes, Java application needs to listen on `0.0.0.0:8080`
 
 You *must* either have the `CC_JAR_PATH` environment variable containing the
 path to your jar or provide a `clevercloud/jar.json` file (jar.json file in
-clevercloud folder which is at the root of you application) that
+clevercloud folder which is at the root of your repository) that
 contains at least the following:
 
 ```json

--- a/deploy/application/java/java-maven.md
+++ b/deploy/application/java/java-maven.md
@@ -42,6 +42,8 @@ Your application must be set to listen on the port 8080.
 
 ### Mandatory configuration
 
+#### Option 1: JSON file in repository
+
 The `clevercloud/maven.json` (maven.json file in clevercloud folder which is at the root of your repository) file must contain the _goal_ field to indicate how to start your application:
 
 ```json
@@ -57,6 +59,14 @@ An example of what can be found as a goal value is:
 ```txt
 "-Dtest.active=false -Dexec.mainClass=\"com.example.Main\" assembly:jar-with-dependencies exec:java"
 ```
+
+#### Option 2: Environment variable
+
+If you don't want to add a file to your repository, or if you're using a monorepository with multiple applications in directories configured with the `APP_FOLDER` environment variable, you'll probably prefer to use an environment variable for deployment configuration.
+
+Simply define `MAVEN_DEPLOY_GOAL="yourgoal"` and it's OK!
+
+Eg. `MAVEN_DEPLOY_GOAL="spring-boot:run"` for a Spring Boot application with spring-boot-maven-plugin
 
 ### Optional configuration
 
@@ -110,6 +120,10 @@ If you need to specify a maven profile (either for the `build` or the `deploy` g
 ```txt
 "-Pmyprofile package"
 ```
+
+Or use the `CC_MAVEN_PROFILES` environment variable.
+
+Eg. `CC_MAVEN_PROFILES="prod"`.
 
 ## Custom run command
 

--- a/deploy/application/java/java-maven.md
+++ b/deploy/application/java/java-maven.md
@@ -42,7 +42,7 @@ Your application must be set to listen on the port 8080.
 
 ### Mandatory configuration
 
-The `clevercloud/maven.json` (maven.json file in clevercloud folder which is at the root of you application) file must contain the _goal_ field to indicate how to start your application:
+The `clevercloud/maven.json` (maven.json file in clevercloud folder which is at the root of your repository) file must contain the _goal_ field to indicate how to start your application:
 
 ```json
   {


### PR DESCRIPTION
- I tried to put the clevercloud folder in my application root (defined with `APP_FOLDER`) but it does not work. It must be in the repository root so I fixed the documentation accordingly.
- When using a monorepository with multiple applications, I had to use environment variables that can be application-specific. Added this alternative in the maven documentation (could also be done in Gradle and perhaps JAR, if you agree with the suggestion). I find it very convenient to use environment variables.