### PR TITLE
Add Environment doc for .NET

### DIFF
--- a/deploy/application/dotnet/dotnet.md
+++ b/deploy/application/dotnet/dotnet.md
@@ -28,6 +28,10 @@ You do not need to change a lot in your application, the *requirements* will hel
 
 {{< readfile "/content/partials/language-specific-deploy/dotnet.md" >}}
 
+{{< readfile "/content/partials/env-injection.md" >}}
+
+To access environment variables from your code, you can use `System.Environment.GetEnvironmentVariable("MY_VARIABLE")"`.
+
 {{< readfile "/content/partials/deploy-git.md" >}}
 
 {{< readfile "/content/partials/link-addon.md" >}}

--- a/develop/env-variables.md
+++ b/develop/env-variables.md
@@ -227,6 +227,7 @@ documentations.
 |[Ruby]({{< ref "deploy/application/ruby/ruby-rack#environment-injection" >}})| ENV["MY\_VAR"] | 
 |[Rust]({{< ref "deploy/application/rust/rust#environment-injection" >}})| std::env::var("MY\_VAR")| 
 |[Scala]({{< ref "deploy/application/scala/scala#environment-injection" >}}) | System.getenv("MY\_VAR") | 
+|[.NET]({{< ref "deploy/application/dotnet/dotnet#environment-injection" ">}}) | System.Environment.GetEnvironmentVariable("MY\_VAR") |
 {{</table>}}
 
 Please note that the variables are available at build-time, for


### PR DESCRIPTION
.NET docs didn't contain info to access environment variables