### PR TITLE
Fix “&lt;options&gt;”

### DIFF
--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -166,7 +166,7 @@ So you can alter the build&start process for your application.
 | <center>Name</center> | <center>Description</center> | <center>Default value</center> | <center>Read Only</center> |
 |-----------------------|------------------------------|--------------------------------|--------------------------------|
 |CC_NODE_DEV_DEPENDENCIES | Control if development dependencies are installed or not. Values are either `install` or `ignore` | `ignore` |  |
-|CC_RUN_COMMAND | Define a custom command. | Example for Meteor: `node .build/bundle/main.js &lt;options&gt;` |  |
+|CC_RUN_COMMAND | Define a custom command. | Example for Meteor: `node .build/bundle/main.js <options>` |  |
 |CC_NODE_BUILD_TOOL | Choose your build tool between `npm`, `npm-ci`, `yarn` and `yarn2` | `npm` |  |
 |CC_CUSTOM_BUILD_TOOL| A custom command to run (overrride `CC_NODE_BUILD_TOOL`) | | |
 |CC_NPM_REGISTRY | The host of your private repository, available values: `github` or the registry host. | registry.npmjs.org |  |


### PR DESCRIPTION
Issue here: https://www.clever-cloud.com/doc/reference/reference-environment-variables/#nodejs

We see HTML tags instead of `<` and `>`:

> ![image](https://user-images.githubusercontent.com/2071331/168609490-6bde2aac-4b0c-4377-b7ef-11e8f4f74810.png)
