### PR TITLE
Add alert in workers section about docker applications

### DIFF
--- a/develop/workers.md
+++ b/develop/workers.md
@@ -10,6 +10,10 @@ keywords:
 
 ## Workers
 
+{{< alert "info" "Docker" >}}
+Note that workers are not available for docker applications.
+{{< /alert >}}
+
 You can run background tasks running in parallel of your application. They will be restarted automatically on error.
 Those are especially useful for environments where you can't have long-running processes such as PHP, Ruby or Python.
 


### PR DESCRIPTION
Workers are not available for Docker applications, this should be stated to prevent users from trying to use it in that case.