### PR TITLE
suggest rake goals in the ruby deployment

### DIFF
--- a/partials/language-specific-deploy/ruby.md
+++ b/partials/language-specific-deploy/ruby.md
@@ -45,10 +45,10 @@ There are many way to add secret key to your env and each one is valid. Clever C
 
 You can specify a list of rake goals to execute before the deployment of your application by using the `CC_RAKEGOALS` environment variable.
 
-The value of this variable must be a comma-separated list of goals:
+The value of this variable must be a comma-separated list of goals, for instance:
 
 ```bash
-CC_RAKEGOALS="goal1, goal2"
+CC_RAKEGOALS="db:migrate, assets:precompile"
 ```
 
 We do not execute any rake goals by default.


### PR DESCRIPTION
Being new to ruby I stumbled on this error:

> The asset "application.css" is not present in the asset pipeline ruby

After some tiresome search I found in [this old clever cloud blogpost](https://www.clever-cloud.com/blog/engineering/2019/05/07/setup-your-ruby-on-rails-online-dev-environment/) where to put this `assets:precompile` line that was suggested everywhere. It turns out this used to be done in a `clevercloud/ruby.json` file:

```json
{
  "deploy" : {
    "rakegoals": ["db:migrate", "assets:precompile"],
    "static": "/public"
  }
}
```

but is now managed with this environment variable:

```
CC_RAKEGOALS="assets:precompile"
```

So I find it usefull to provide it in the docs, as an example, to save other people some time.
