### PR TITLE
Add documentation about migrating to another zone

### DIFF
--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -55,7 +55,7 @@ and your PostgreSQL add-on is still in Paris, your application will need extra t
 Once your application has been migrated to your target zone, you will find in the `Domain names` section the new `A` and `CNAME` DNS records to use for your application's domains.
 If you were using `A` records, update the records (there might be more or fewer of them than what you had previously, this is normal). If you used a `CNAME` record, simply change the value.
 
-Once done, it will take as much time to propagate as to what value was defined your TTL for that record. If you followed the prerequisites above, it should take a few minutes tops.
+Once done, it will take as much time to propagate as the TTL defined for that record. If you followed the prerequisites above, it should take a few minutes tops.
 
 ### Migration
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -66,7 +66,7 @@ After saving, you can now redeploy your application in the `Overview`, it will r
 
 ### Applications using an FSBucket
 
-FSBuckets can only be mounted by applications on the same zone. This means that you can' use a FSBucket add-on hosted on Paris if your application is on Montreal.
+FSBuckets can only be mounted by applications on the same zone. This means that you can't use a FSBucket add-on hosted on Paris if your application is on Montreal.
 
 To migrate FSBuckets, see the [section below](#fsbucket).
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -102,7 +102,7 @@ Add-ons can be migrated from one zone to another. For some of them, our support 
 These add-ons can be migrated using the [Migration Tool]({{< ref "/administrate/database-migration" >}}).
 
 Once your migration is over, the services connecting to the add-on might be impacted by an increased latency due to DNS updates. The domain of your add-on will have its DNS records
-changed but it will take up to 1 hour for them to propagate. This means that during that time, your services might still connect to the old zone which will then redirect to the target zone
+changed but it will take up to 1 hour for them to propagate. This means that during that time, your services might still connect to the old zone, which will then redirect to the target zone
 where your database has been migrated.
 
 ### Jenkins, Elasticsearch, Cellar, Pulsar

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -48,7 +48,7 @@ may increase the latency for your users. For example, if you are migrating from 
 then redirect the trafic to our Montreal infrastructure, leading to requests taking more time.
 
 You might also experience an increased latency between your application and other services (like a PostgreSQL add-on for example). If your application has switched to the Montreal zone
-and your PostgreSQL add-on is still in Paris, your application will need extract time to query the database.
+and your PostgreSQL add-on is still in Paris, your application will need extra time to query the database.
 
 #### DNS updates
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -43,7 +43,7 @@ After the migration, you can set back your old TTL value.
 
 #### Increased latency
 
-Once your application has been redeployed to your target zone, your application's domain will still have its DNS pointing to the old zone. As a consequence, it
+Once your application has been redeployed to your target zone, your application's domain will still have its DNS pointing to the old zone. As a consequence, the
 may increase the latency for your users. For example, if you are migrating from Paris (PAR) to Montreal (MTL), your visitors will connect to our Paris infrastructure, which will
 then redirect the trafic to our Montreal infrastructure, leading to requests taking more time.
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -44,7 +44,7 @@ After the migration, you can set back your old TTL value.
 #### Increased latency
 
 Once your application has been redeployed to your target zone, your application's domain will still have its DNS pointing to the old zone. As a consequence, the
-may increase the latency for your users. For example, if you are migrating from Paris (PAR) to Montreal (MTL), your visitors will connect to our Paris infrastructure, which will
+latency may increase for your users. For example, if you are migrating from Paris (PAR) to Montreal (MTL), your visitors will connect to our Paris infrastructure, which will
 then redirect the trafic to our Montreal infrastructure, leading to requests taking more time.
 
 You might also experience an increased latency between your application and other services (like a PostgreSQL add-on for example). If your application has switched to the Montreal zone

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -59,7 +59,7 @@ Once done, it will take as much time to propagate as the TTL defined for that re
 
 ### Migration
 
-If your application doesn't match any criteria of the list in the `Application migration` section, then you can go to the `Information` pane of your application and under the `Zone` label, chose your target zone.
+If your application doesn't match any criteria of the list in the `Application migration` section, then you can go to the `Information` pane of your application. Under the `Zone` label, chose your target zone.
 Once selected, you can save your changes using the `Save` button at the bottom of the page.
 
 After saving, you can now redeploy your application in the `Overview`, it will redeploy on the new zone.

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -78,7 +78,7 @@ When domains are switched from the old application to the new one, a small downt
 First, create a new PHP application on your target zone.
 Then, you can easily copy / paste the environment variable from the old application to the new one using the `Expert mode` of our environment variables interface.
 Don't forget to link all services that were linked to your old application. Linking multiple times the same service to different application doesn't cause any issue.
-Make sure the Scalability section of your application is the same as the old one as well as the various options (HTTPS redirection, build cache, ...) you can find in the `Information pane`.
+Make sure the Scalability section of your application is the same as the old one, as well as the various options you can find in the `Information pane` (HTTPS redirection, build cache, ...).
 
 Once everything is setup again, we can push the code. If you are using Git, you can find the new Git URL in the `Information` pane.
 If you are using FTP, please read the [FSBucket migration section](#fsbucket).

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -1,0 +1,120 @@
+---
+title: Zone Migration
+tags:
+- migration
+- zone
+- application
+- addon
+---
+
+# Migrate your services from one zone to another
+
+In this document, we will see how you can migrate your Clever Cloud services from one zone to another zone, for example from Paris to Montreal.
+
+For most of the services, you will be able to migrate them as-is. For others, you will need to create them and do a manual migration.
+
+Keep in mind that our support team remains available should you have any questions regarding zone migration.
+
+## Application migration
+
+Most of the applications will be able to be migrated without issues. If your application matches any criteria is in the list below, you will need extra steps
+described in the following sub-sections.
+
+- Any application that uses a FSBucket add-on
+- PHP applications
+
+If your application matches any criterias on this list, please read the prerequisites below first and then follow the right sub-section.
+
+### Prerequisites
+
+Besides redeploying your application in your target zone, you have to keep a few things in mind:
+- Increased latency might be observed during DNS propagation (more below)
+- You will need to update your DNS settings so make sure you have access to your DNS registrar
+
+One of the first things you can do is to lower your DNS records TTL (time to live) to speed up the DNS propagation when you will update your domains DNS records.
+
+On your registrar's interface, find your application's domain. Usually, the DNS record will be `domain.tld IN CNAME domain.<current-zone>.clever-cloud.com` with a certain TTL.
+Update that TTL to 60 seconds instead and wait for this change to propagate (wait as much time as the old TTL value). This change will allow a faster DNS propagation when
+you will have to update the `CNAME` record value to `domain.<target-zone>.clever-cloud.com`, lowering the amount of time your users will experience an increased latency.
+
+{{< alert "info" "Note" >}}
+After the migration, you can set back your old TTL value.
+{{< /alert >}}
+
+#### Increased latency
+
+Once your application has been redeployed to your target zone, your application's domain will still have its DNS pointing to the old zone. As a consequence, it
+may increase the latency for your users. For example, if you are migrating from Paris (PAR) to Montreal (MTL), your visitors will connect to our Paris infrastructure that will
+then redirect the trafic on our Montreal infrastructure, leading to requests taking more time.
+
+You might also experience an increased latency between your application and other services (like a PostgreSQL add-on for example). If your application has switched to the Montreal zone
+and your PostgreSQL add-on is still in Paris, your application will need extract time to query the database.
+
+#### DNS updates
+
+Once your application has been migrated to your target zone, you will find in the `Domain names` section the new `A` and `CNAME` DNS records to use for your application's domains.
+If you were using `A` records, update the records (there might be more or less than what you had previously, this is normal). If you used a `CNAME` record, simply change the value.
+
+Once done, it will take as much time to propagate as to what value was defined your TTL for that record. If you followed the prerequisites above, it should take a few minutes tops.
+
+### Migration
+
+If your application doesn't match any criteria of the list in the `Application migration` section, then you can go to the `Information` pane of your application and under the `Zone` label, chose your target zone.
+Once selected, you can save your changes using the `Save` button at the bottom of the page.
+
+After saving, you can now redeploy your application in the `Overview`, it will redeploy on the new zone.
+
+### Applications using an FSBucket
+
+FSBuckets can only be mounted by applications on the same zone. This means that you can' use a FSBucket add-on hosted on Paris if your application is on Montreal.
+
+To migrate FSBuckets, see the [section below](#fsbucket).
+
+### PHP Applications
+
+Due to technical reasons, a PHP application can't be migrated to another zone. In this case, you will have to re-create the application.
+When domains will be switched to the old application to the new one, a small downtime may occur. 404 or 503 errors might happen for a few seconds.
+
+First, create a new PHP application on your target zone.
+Then, you can easily copy / paste the environment variable from the old application to the new one using the `Expert mode` of our environment variables interface.
+Don't forget to link any services that are linked to your old application. Linking multiple times the same service to different application doesn't cause any issues.
+Make sure the Scalability section of your application is the same as the old one as well as the various options (HTTPS redirection, build cache, ...) you can find in the `Information pane`.
+
+Once everything is setup again, we can push the code. If you are using Git, you can find the new Git URL in the `Information` pane.
+If you are using FTP, please read the [FSBucket migration section](#fsbucket).
+
+Your new application should now be deployed. You can now update the domain names: for each domain on your old application, delete the domain and add it to the new application.
+
+You can use the CLI to do it and minimize the downtime:
+
+```shell
+clever -a <old-application-alias> domain rm <domain>; clever -a <new-application-alias> domain add <domain>
+```
+
+You can now update your DNS as described in the [DNS updates](#dns-updates) section.
+
+## Add-on migration
+
+Add-ons can be migrated from one zone to another. For some of them, our support team can help you do it.
+
+### PostgreSQL, MySQL, MongoDB, Redis
+
+Those add-ons can be migrated using the [Migration Tool]({{< ref "/administrate/database-migration" >}}).
+
+Once your migration is over, services connecting to the add-on might be impacted by an increased latency due to DNS updates. The domain of your add-on will have its DNS records
+changed but it will take up to 1 hour for them to propagate. This means that during that time, your services might still connect to the old zone which will then redirect to the target zone
+where your database has been migrated.
+
+### Jenkins, Elasticsearch, Cellar, Pulsar
+
+Those add-ons can't be automatically migrated across zones. Please reach out to our support team so we can assist you further for this migration.
+
+### FSBucket
+
+FSBuckets can't be migrated across zones either. You will have to create a new add-on on the target zone and transfer the content from the old add-on to the new one.
+
+To do so, you can use the `lftp` or `rclone` tools. Or you can ask our support team and we will be able to do it for you.
+
+{{< alert "warning" "Note" >}}
+In case of a FSBucket add-on (and not a PHP+FTP add-on), you will have to remember to link it to your application once it has been migrated to the new zone.
+{{< /alert >}}

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -29,7 +29,7 @@ In this case, please read the prerequisites below first and then follow the righ
 
 Besides redeploying your application in your target zone, you have to keep a few things in mind:
 - Increased latency might be observed during DNS propagation (more below)
-- You will need to update your DNS settings so make sure you have access to your DNS registrar
+- You will need to update your DNS settings, so make sure you have access to your DNS registrar
 
 One of the first things you can do is to lower your DNS records TTL (time to live) to speed up the DNS propagation when you will update your domains DNS records.
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -53,7 +53,7 @@ and your PostgreSQL add-on is still in Paris, your application will need extra t
 #### DNS updates
 
 Once your application has been migrated to your target zone, you will find in the `Domain names` section the new `A` and `CNAME` DNS records to use for your application's domains.
-If you were using `A` records, update the records (there might be more or less than what you had previously, this is normal). If you used a `CNAME` record, simply change the value.
+If you were using `A` records, update the records (there might be more or fewer of them than what you had previously, this is normal). If you used a `CNAME` record, simply change the value.
 
 Once done, it will take as much time to propagate as to what value was defined your TTL for that record. If you followed the prerequisites above, it should take a few minutes tops.
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -72,7 +72,7 @@ To migrate FSBuckets, see the [section below](#fsbucket).
 
 ### PHP Applications
 
-Due to technical reasons, a PHP application can't be migrated to another zone. In this case, you will have to re-create the application.
+Because of technical reasons, a PHP application can not be migrated to another zone. In this case, you will have to re-create the application.
 When domains will be switched to the old application to the new one, a small downtime may occur. 404 or 503 errors might happen for a few seconds.
 
 First, create a new PHP application on your target zone.

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -34,7 +34,7 @@ Besides redeploying your application in your target zone, you have to keep a few
 One of the first things you can do is to lower your DNS records TTL (time to live). in order to speed up the DNS propagation during the update of your domains DNS records.
 
 On your registrar's interface, find your application's domain. Usually, the DNS record will be `domain.tld IN CNAME domain.<current-zone>.clever-cloud.com` with a certain TTL.
-Update that TTL to 60 seconds instead and wait for this change to propagate (wait as much time as the old TTL value). This change will allow a faster DNS propagation when
+Edit that TTL to 60 seconds instead of the existing value, and wait for this change to propagate (wait as much time as the old TTL value). This change will allow a faster DNS propagation when
 you will have to update the `CNAME` record value to `domain.<target-zone>.clever-cloud.com`, lowering the amount of time your users will experience an increased latency.
 
 {{< alert "info" "Note" >}}

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -66,7 +66,7 @@ After saving, you can now redeploy your application in the `Overview`, it will r
 
 ### Applications using an FSBucket
 
-FSBuckets can only be mounted by applications on the same zone. This means that you can't use a FSBucket add-on hosted on Paris if your application is on Montreal.
+FSBuckets can only be mounted by applications on the same zone. This means that you can not use an FSBucket add-on hosted in Paris, if your application is in Montreal.
 
 To migrate FSBuckets, see the [section below](#fsbucket).
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -31,11 +31,11 @@ Besides redeploying your application in your target zone, you have to keep a few
 - Increased latency might be observed during DNS propagation (more below)
 - You will need to update your DNS settings, so make sure you have access to your DNS registrar
 
-One of the first things you can do is to lower your DNS records TTL (time to live). in order to speed up the DNS propagation during the update of your domains DNS records.
+One of the first things you can do is to lower your DNS records TTL (time to live). In order to speed up the DNS propagation during the update of your domains DNS records.
 
 On your registrar's interface, find your application's domain. Usually, the DNS record will be `domain.tld IN CNAME domain.<current-zone>.clever-cloud.com` with a certain TTL.
 Edit that TTL to 60 seconds instead of the existing value, and wait for this change to propagate (wait as much time as the old TTL value). This change will allow a faster DNS propagation when
-you will have to update the `CNAME` record value to `domain.<target-zone>.clever-cloud.com`, lowering the amount of time your users will experience an increased latency.
+you have to update the `CNAME` record value to `domain.<target-zone>.clever-cloud.com`, lowering the amount of time your users will experience an increased latency.
 
 {{< alert "info" "Note" >}}
 After the migration, you can set back your old TTL value.
@@ -45,7 +45,7 @@ After the migration, you can set back your old TTL value.
 
 Once your application has been redeployed to your target zone, your application's domain will still have its DNS pointing to the old zone. As a consequence, the
 latency may increase for your users. For example, if you are migrating from Paris (PAR) to Montreal (MTL), your visitors will connect to our Paris infrastructure, which will
-then redirect the trafic to our Montreal infrastructure, leading to requests taking more time.
+then redirect the traffic to our Montreal infrastructure, leading requests to take more time.
 
 You might also experience an increased latency between your application and other services (like a PostgreSQL add-on for example). If your application has switched to the Montreal zone
 and your PostgreSQL add-on is still in Paris, your application will need extra time to query the database.
@@ -66,7 +66,7 @@ After saving, you can now redeploy your application in the `Overview`, it will r
 
 ### Applications using an FSBucket
 
-FSBuckets can only be mounted by applications on the same zone. This means that you can not use an FSBucket add-on hosted in Paris, if your application is in Montreal.
+FSBuckets can only be mounted by applications on the same zone. This means that you cannot use an FSBucket add-on hosted in Paris, if your application is in Montreal.
 
 To migrate FSBuckets, see the [section below](#fsbucket).
 
@@ -80,7 +80,7 @@ Then, you can easily copy / paste the environment variable from the old applicat
 Don't forget to link all services that were linked to your old application. Linking multiple times the same service to different application doesn't cause any issue.
 Make sure the Scalability section of your application is the same as the old one, as well as the various options you can find in the `Information pane` (HTTPS redirection, build cache, ...).
 
-Once everything is setup again, we can push the code. If you are using Git, you can find the new Git URL in the `Information` pane.
+Once everything is setup again, we can push the code. If you are using Git, you can find the new Git URL in the `Information` panel.
 If you are using FTP, please read the [FSBucket migration section](#fsbucket).
 
 Your new application should now be deployed. You can update the domain names: for each domain of your old application, delete it and add it to the new application.

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -73,7 +73,7 @@ To migrate FSBuckets, see the [section below](#fsbucket).
 ### PHP Applications
 
 Because of technical reasons, a PHP application can not be migrated to another zone. In this case, you will have to re-create the application.
-When domains will be switched to the old application to the new one, a small downtime may occur. 404 or 503 errors might happen for a few seconds.
+When domains are switched from the old application to the new one, a small downtime may occur. 404 or 503 errors might happen for a few seconds.
 
 First, create a new PHP application on your target zone.
 Then, you can easily copy / paste the environment variable from the old application to the new one using the `Expert mode` of our environment variables interface.

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -107,7 +107,7 @@ where your database has been migrated.
 
 ### Jenkins, Elasticsearch, Cellar, Pulsar
 
-Those add-ons can't be automatically migrated across zones. Please reach out to our support team so we can assist you further for this migration.
+These add-ons can not be automatically migrated across zones. Please reach out to our support team so we can assist you further for this migration.
 
 ### FSBucket
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -17,7 +17,7 @@ Keep in mind that our support team remains available, should you have any questi
 
 ## Application migration
 
-Most of the applications will be able to be migrated without issues. If your application matches any criteria is in the list below, you will need extra steps
+Most of the applications will migrate without issues. If one of your applications matches any criteria is in the list below, you will need extra steps
 described in the following sub-sections.
 
 - Any application that uses a FSBucket add-on

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -111,7 +111,7 @@ These add-ons can not be automatically migrated across zones. Please reach out t
 
 ### FSBucket
 
-FSBuckets can't be migrated across zones either. You will have to create a new add-on on the target zone and transfer the content from the old add-on to the new one.
+FSBuckets can not be migrated across zones either. You will have to create a new FSBucket in the target zone and transfer its content from the old to the new one.
 
 To do so, you can use the `lftp` or `rclone` tools. Or you can ask our support team and we will be able to do it for you.
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -77,7 +77,7 @@ When domains are switched from the old application to the new one, a small downt
 
 First, create a new PHP application on your target zone.
 Then, you can easily copy / paste the environment variable from the old application to the new one using the `Expert mode` of our environment variables interface.
-Don't forget to link any services that are linked to your old application. Linking multiple times the same service to different application doesn't cause any issues.
+Don't forget to link all services that were linked to your old application. Linking multiple times the same service to different application doesn't cause any issue.
 Make sure the Scalability section of your application is the same as the old one as well as the various options (HTTPS redirection, build cache, ...) you can find in the `Information pane`.
 
 Once everything is setup again, we can push the code. If you are using Git, you can find the new Git URL in the `Information` pane.

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -44,7 +44,7 @@ After the migration, you can set back your old TTL value.
 #### Increased latency
 
 Once your application has been redeployed to your target zone, your application's domain will still have its DNS pointing to the old zone. As a consequence, it
-may increase the latency for your users. For example, if you are migrating from Paris (PAR) to Montreal (MTL), your visitors will connect to our Paris infrastructure that will
+may increase the latency for your users. For example, if you are migrating from Paris (PAR) to Montreal (MTL), your visitors will connect to our Paris infrastructure, which will
 then redirect the trafic on our Montreal infrastructure, leading to requests taking more time.
 
 You might also experience an increased latency between your application and other services (like a PostgreSQL add-on for example). If your application has switched to the Montreal zone

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -83,7 +83,7 @@ Make sure the Scalability section of your application is the same as the old one
 Once everything is setup again, we can push the code. If you are using Git, you can find the new Git URL in the `Information` pane.
 If you are using FTP, please read the [FSBucket migration section](#fsbucket).
 
-Your new application should now be deployed. You can now update the domain names: for each domain on your old application, delete the domain and add it to the new application.
+Your new application should now be deployed. You can update the domain names: for each domain of your old application, delete it and add it to the new application.
 
 You can use the CLI to do it and minimize the downtime:
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -45,7 +45,7 @@ After the migration, you can set back your old TTL value.
 
 Once your application has been redeployed to your target zone, your application's domain will still have its DNS pointing to the old zone. As a consequence, it
 may increase the latency for your users. For example, if you are migrating from Paris (PAR) to Montreal (MTL), your visitors will connect to our Paris infrastructure, which will
-then redirect the trafic on our Montreal infrastructure, leading to requests taking more time.
+then redirect the trafic to our Montreal infrastructure, leading to requests taking more time.
 
 You might also experience an increased latency between your application and other services (like a PostgreSQL add-on for example). If your application has switched to the Montreal zone
 and your PostgreSQL add-on is still in Paris, your application will need extract time to query the database.

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -101,7 +101,7 @@ Add-ons can be migrated from one zone to another. For some of them, our support 
 
 These add-ons can be migrated using the [Migration Tool]({{< ref "/administrate/database-migration" >}}).
 
-Once your migration is over, services connecting to the add-on might be impacted by an increased latency due to DNS updates. The domain of your add-on will have its DNS records
+Once your migration is over, the services connecting to the add-on might be impacted by an increased latency due to DNS updates. The domain of your add-on will have its DNS records
 changed but it will take up to 1 hour for them to propagate. This means that during that time, your services might still connect to the old zone which will then redirect to the target zone
 where your database has been migrated.
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -13,7 +13,7 @@ In this document, we will see how you can migrate your Clever Cloud services fro
 
 For most of the services, you will be able to migrate them as-is. For others, you will need to create them and do a manual migration.
 
-Keep in mind that our support team remains available should you have any questions regarding zone migration.
+Keep in mind that our support team remains available, should you have any questions regarding zone migration.
 
 ## Application migration
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -23,7 +23,7 @@ described in the following sub-sections.
 - Any application that uses a FSBucket add-on
 - PHP applications
 
-If your application matches any criterias on this list, please read the prerequisites below first and then follow the right sub-section.
+In this case, please read the prerequisites below first and then follow the right sub-section.
 
 ### Prerequisites
 

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -99,7 +99,7 @@ Add-ons can be migrated from one zone to another. For some of them, our support 
 
 ### PostgreSQL, MySQL, MongoDB, Redis
 
-Those add-ons can be migrated using the [Migration Tool]({{< ref "/administrate/database-migration" >}}).
+These add-ons can be migrated using the [Migration Tool]({{< ref "/administrate/database-migration" >}}).
 
 Once your migration is over, services connecting to the add-on might be impacted by an increased latency due to DNS updates. The domain of your add-on will have its DNS records
 changed but it will take up to 1 hour for them to propagate. This means that during that time, your services might still connect to the old zone which will then redirect to the target zone

--- a/administrate/zone-migration.md
+++ b/administrate/zone-migration.md
@@ -31,7 +31,7 @@ Besides redeploying your application in your target zone, you have to keep a few
 - Increased latency might be observed during DNS propagation (more below)
 - You will need to update your DNS settings, so make sure you have access to your DNS registrar
 
-One of the first things you can do is to lower your DNS records TTL (time to live) to speed up the DNS propagation when you will update your domains DNS records.
+One of the first things you can do is to lower your DNS records TTL (time to live). in order to speed up the DNS propagation during the update of your domains DNS records.
 
 On your registrar's interface, find your application's domain. Usually, the DNS record will be `domain.tld IN CNAME domain.<current-zone>.clever-cloud.com` with a certain TTL.
 Update that TTL to 60 seconds instead and wait for this change to propagate (wait as much time as the old TTL value). This change will allow a faster DNS propagation when


### PR DESCRIPTION
This is a first version of a documentation page explaining to users how to migrate their services from one zone to another, with a few tips to help them.

I've put it under the Administrate section, not sure if that's the best place. Comments welcome!