### PR TITLE
Add Elasticsearch version 8 in the supported versions

### DIFF
--- a/deploy/addon/elastic.md
+++ b/deploy/addon/elastic.md
@@ -18,7 +18,7 @@ Provisioning the Elastic Stack addon on Clever Cloud will give you an Elasticsea
 
 ## Versions
 
-The current versions supported at add-on creation are 6 and 7.
+The current versions supported at add-on creation are 6, 7 and 8.
 
 ## Elasticsearch
 

--- a/deploy/addon/elastic.md
+++ b/deploy/addon/elastic.md
@@ -18,7 +18,7 @@ Provisioning the Elastic Stack addon on Clever Cloud will give you an Elasticsea
 
 ## Versions
 
-The current versions supported at add-on creation are 6, 7 and 8.
+The current versions supported at add-on creation are 7 and 8.
 
 ## Elasticsearch
 


### PR DESCRIPTION
I had confirmation by the support chat that version 8.3 is available.