### PR TITLE
php.md: fix render of code block

### DIFF
--- a/partials/language-specific-deploy/php.md
+++ b/partials/language-specific-deploy/php.md
@@ -237,9 +237,7 @@ $pg = new PDO("postgresql:host={$host};dbname={$database}, $username, $password)
     <p>Environment variables are displayed in the default output of `phpinfo()`.
     If you want to use `phpinfo()` without exposing environment variables, you have to call it this way:
     </p>
-    ```php
-    phpinfo(INFO_GENERAL | INFO_CREDITS | INFO_CONFIGURATION | INFO_MODULES | INFO_LICENSE)
-    ```
+    <code>phpinfo(INFO_GENERAL | INFO_CREDITS | INFO_CONFIGURATION | INFO_MODULES | INFO_LICENSE)</code>
 {{< /alert >}}
 
 ## Composer


### PR DESCRIPTION
The block code wasn't interpreted:

> ![image](https://user-images.githubusercontent.com/2071331/233052680-e41ef13e-83cd-4521-b637-34bae0409b81.png)

I didn't tested the change.