### PR TITLE
env-vars: Various Markdown and grammar improvements/fixes

### DIFF
--- a/develop/env-variables.md
+++ b/develop/env-variables.md
@@ -19,15 +19,14 @@ injected in your application's environment.
 
 Variables are defined on a per-application basis. They are defined in four ways:
 
- * By provisioned add-ons linked to applications. The variables names
-   are listed in the add-on's information panel
+* By provisioned add-ons linked to applications. The variables names
+  are listed in the add-on's information panel.
 
- * By linked applications with exposed configuration
+* By linked applications with exposed configuration.
 
- * By adding variables yourself in the "Environment variables" panel of
-   your application.
+* By adding variables yourself in the "Environment variables" panel of your application.
 
- * Some environment variables are added automatically for each application.
+* Some environment variables are added automatically for each application.
 
 Please note that if you define or modify environment variables, you will
 need to redeploy your application to make it use the new variables.
@@ -41,26 +40,28 @@ to inform you about the current context of your application and about the applic
 
 They can be accessed as classic environment variables.
 
- * `APP_ID`: the ID of the application. Each application has a unique identifier used to
- identify it in our system. This ID is the same than the one you can find in the information
- section of your application.
+* `APP_ID`: the ID of the application. Each application has a unique identifier used to
+  identify it in our system. This ID is the same than the one you can find in the information
+  section of your application.
 
- * `INSTANCE_ID`: the ID of the current instance (scaler) of your application. It's unique for each
- instance of your application and changes every time you deploy it.
+* `INSTANCE_ID`: the ID of the current instance (scaler) of your application. It's unique for each
+  instance of your application and changes every time you deploy it.
 
- * `INSTANCE_TYPE`: The type of the instance (scaler). Its value can be `build` or `production`. `build` is when
- your application is being built on a [dedicated instance]({{< ref "administrate/apps-management.md#edit-application-configuration" >}}).
+* `INSTANCE_TYPE`: The type of the instance (scaler). Its value can be `build` or `production`.
+  `build` is when your application is being built on a [dedicated instance][dedicated-instance].
 
- * `COMMIT_ID`: the commit ID used as a base to deploy your application. As we remove
- the `.git` directory before the deployment (to avoid security problems), it can be used
- to know which version of your application is running on the server.
+* `COMMIT_ID`: the commit ID used as a base to deploy your application. As we remove
+  the `.git` directory before the deployment (to avoid security problems), it can be used
+  to know which version of your application is running on the server.
 
- * `APP_HOME`: The absolute path of your application on the server. Can be used to
- create absolute links in your application (e.g. ${APP_HOME}/foo/bar).
+* `APP_HOME`: The absolute path of your application on the server. Can be used to
+  create absolute links in your application (e.g. `${APP_HOME}/foo/bar`).
 
- * `CC_PRETTY_INSTANCE_NAME`: A random string name generated for each instance using pokemon names.
+* `CC_PRETTY_INSTANCE_NAME`: A random string name generated for each instance using pokemon names.
 
- * `INSTANCE_NUMBER`: See below
+* `INSTANCE_NUMBER`: See below
+
+[dedicated-instance]: {{< ref "administrate/apps-management.md#edit-application-configuration" >}}
 
 ### What is the `INSTANCE_NUMBER` variable used for?
 
@@ -68,19 +69,21 @@ This variable allows your application to differentiate each running node on the 
 
 It will contain a different number for each instance of your application.
 
-For example, if three instances are running, it will contain `0` for the first, `1`
-for the second and `2` for the third.
-It's handy if you want to only run crons on 1 instance (e.g. only on instance 0)
+For example, if three instances are running, it will contain `0` for the first,
+`1` for the second and `2` for the third.
+It's handy if you want to only run crons on 1 instance (e.g. only on instance 0).
 
 ## Settings you can define using environment variables
 
 We use environment variables for some settings:
 
- * `IGNORE_FROM_BUILDCACHE`: allows you to specify paths to ignore when the build
- cache archive is created. Must be relative to your application root.
- (ex: `foo/bar:foo/baz` where `bar` or `baz` can be either a folder or a file)
+* `IGNORE_FROM_BUILDCACHE`: allows you to specify paths to ignore when the build
+  cache archive is created. Must be relative to your application root.
+  (e.g. `foo/bar:foo/baz` where `bar` or `baz` can be either a directory or a file)
 
-* `CC_OVERRIDE_BUILDCACHE`: allows you to specify paths that will be in the build cache. Only those files / directories will be cached. (ex: `foo/bar:foo/baz` where `bar` or `baz` can be either a folder or a file)
+* `CC_OVERRIDE_BUILDCACHE`: allows you to specify paths that will be in the build cache.
+  Only those files/directories will be cached
+  (e.g. `foo/bar:foo/baz` where `bar` or `baz` can be either a directory or a file).
 
 ## Environment variables rules and formats
 
@@ -89,150 +92,151 @@ examples of the formats available on our different modes.
 
 ### Rules
 
-* Letters (ASCII only, upper and lower case) 
-  * Valid: 
-    * `user_id`    
-    * `USER_ID`
-    * `UsERId`
-    * `userid`
-    * `USERID`
-  * Not Valid:
-    * `user_id?`
-    * `?userid`
-    * `user.id`
-    * `user id`
+* Letters (ASCII only, upper and lower case)
+  * Valid: `user_id`, `USER_ID`, `UsERId`, `userid`, `USERID`
+  * Invalid: `user_id?`, `?userid`, `user.id`, `user id`
 * Digits (but not for first character)
-  * Valid: 
-    * `user2id`
-    * `userid42`
-  * Not Valid:
-    * `2userid`
-    * `1user_Id`
-* Underscores 
-  * Valid: 
-    * `user_id`
-    * `all_user_id`
-    * `_user_id`
-    * `_user_id__`
+  * Valid: `user2id`, `userid42`
+  * Invalid: `2userid`, `1user_Id`
+* Underscores
+  * Valid: `user_id`, `all_user_id`, `_user_id`, `_user_id__`
 * Everything else is not allowed
 
-### Java properties rules exception
+#### Java properties rules exception
 
 In case of a Java application you can also use:
 
 * Dashes
-  * Valid: 
-    * `spring-boot`
-    * `spring-boot-database`
-    * `--spring-boot`
-    * `--spring`
+  * Valid: `spring-boot`, `spring-boot-database`, `--spring-boot`, `--spring`
 * Dots
-  * Valid: 
-    * `spring.boot`
-    * `spring.datasource.url`
-    * `.spring.url`
+  * Valid: `spring.boot`, `spring.datasource.url`, `.spring.url`
 
 ### Format
 
-Here are some formats that you can use when changing your variables
-on our expert and JSON mode. 
-Note: For each mode you can obviously have multiple environment variables.
+Here are some formats that you can use when editing your variables
+in our ["expert"](#expert) and [JSON](#json) modes.
 
 #### Expert
 
-The format of an expert variable is: `VAR_NAME="VALUE"`
+The format of an expert variable is `VAR_NAME="VAR_VALUE"`.
 
-Here are some examples for the mode: 
+Here are some examples:
 
-- Multiple variables examples: 
-```bash
-EMPTY=""
-MULTI="line one
-line two
-line three"
-ONE="value ONE"
-TWO="value TWO"
-```
+* Multiple variables examples:
 
-- Multiline:
-```bash
-MULTI="line one
-line two
-line three"
-```
+  ```bash
+  EMPTY=""
+  MULTI="line one
+  line two
+  line three"
+  ONE="value ONE"
+  TWO="value TWO"
+  ```
 
-- Empty value:
-```bash
-EMPTY=""
-```
+* Multiline:
+
+  ```bash
+  MULTI="line one
+  line two
+  line three"
+  ```
+
+* Empty value:
+
+  ```bash
+  EMPTY=""
+  ```
 
 #### JSON
 
-The format of a JSON variable is: `{ "name": "THE_NAME", "value": "the value" }`. 
+The format of a JSON variable is `{ "name": "VAR_NAME", "value": "VAR_VALUE" }`.
+
 Note: You must put these variables in an array (see the multiple variable example to see how it goes).
 
-Here are some examples for the mode: 
-- Multiline:
-```json
-{
-  "name": "MULTI",
-  "value": "line one\nline two\nline three"
-}
-```
-- Empty value:
-```json
-{
-  "name": "EMPTY",
-  "value": ""
-}
-```
-- Multiple variables examples: 
-```json
-[
-  {
-    "name": "EMPTY",
-    "value": ""
-  },
+Here are some examples:
+
+* Multiline:
+
+  ```json
   {
     "name": "MULTI",
     "value": "line one\nline two\nline three"
-  },
-  {
-    "name": "ONE",
-    "value": "value ONE"
-  },
-  {
-    "name": "TWO",
-    "value": "value TWO"
   }
-]
-```
+  ```
+
+* Empty value:
+
+  ```json
+  {
+    "name": "EMPTY",
+    "value": ""
+  }
+  ```
+
+* Multiple variables examples:
+
+  ```json
+  [
+    {
+      "name": "EMPTY",
+      "value": ""
+    },
+    {
+      "name": "MULTI",
+      "value": "line one\nline two\nline three"
+    },
+    {
+      "name": "ONE",
+      "value": "value ONE"
+    },
+    {
+      "name": "TWO",
+      "value": "value TWO"
+    }
+  ]
+  ```
 
 ## How do I use these variables?
 
-Depending on the type of your application, you will need to use
-different ways. You can find the various ways in the specific instances
-documentations.
+Depending on the type of your application, the code will differ.
+You can find more information in the documentation pages related to your application type.
+
+Here is a non-exhaustive summary:
 
 {{<table "table table-bordered table-striped dataTable" >}}
-| language | use case | 
-|----------|----------|
-| [Go]({{< ref "deploy/application/golang/go#environment-injection.md" >}}) | Os.Getenv["MY\_VAR"]|
-| [Haskell]({{< ref "deploy/application/haskell/haskell#environment-injection" >}})   |Os.Getenv["MY\_VAR"]  |
-| [Node.js]({{< ref "deploy/application/javascript/by-framework/nodejs#environment-injection" >}})  | process.env["MY\_VAR"]|
-| [Java WAR]({{< ref "deploy/application/java/java-war#environment-injection" >}}) | System.getProperties().getProperty("MY\_VAR") |
-|[PHP]({{< ref "deploy/application/php/php-apps#environment-injection" >}})| getenv("MY\_VAR") | |
-|[Play! Framework 1]({{< ref "deploy/application/java/by-framework/play-framework-1#environment-injection" >}}) & [Play! Framework 2]({{< ref "deploy/application/java/by-framework/play-framework-2#environment-injection" >}})| System.getenv("MY\_VAR") or ${MY\_VAR} in application.conf | 
-|[Python]({{< ref "deploy/application/python/python_apps#environment-injection" >}})| os.getenv("MY\_VAR") | 
-|[Ruby]({{< ref "deploy/application/ruby/ruby-rack#environment-injection" >}})| ENV["MY\_VAR"] | 
-|[Rust]({{< ref "deploy/application/rust/rust#environment-injection" >}})| std::env::var("MY\_VAR")| 
-|[Scala]({{< ref "deploy/application/scala/scala#environment-injection" >}}) | System.getenv("MY\_VAR") | 
-|[.NET]({{< ref "deploy/application/dotnet/dotnet#environment-injection" >}}) | System.Environment.GetEnvironmentVariable("MY\_VAR") |
+| Language | Usage |
+|----------|-------|
+| [Go][go] | `Os.Getenv["MY_VAR"]`|
+| [Haskell][haskell] | `Os.Getenv["MY_VAR"]` |
+| [Node.js][node] | `process.env["MY_VAR"]`|
+| [Java WAR][java-war] | `System.getProperties().getProperty("MY_VAR")` |
+| [PHP][php] | `getenv("MY_VAR")` |
+| [Play! Framework 1][play-1] & [Play! Framework 2][play-2] | `System.getenv("MY_VAR")` or `${MY_VAR}` in `application.conf` |
+| [Python][python] | `os.getenv("MY_VAR")` |
+| [Ruby][ruby] | `ENV["MY_VAR"]` |
+| [Rust][rust] | `std::env::var("MY_VAR")` |
+| [Scala][scala] | `System.getenv("MY_VAR")` |
+| [.NET][dotnet] | `System.Environment.GetEnvironmentVariable("MY_VAR")` |
+
+[go]: {{< ref "deploy/application/golang/go#environment-injection.md" >}}
+[haskell]: {{< ref "deploy/application/haskell/haskell#environment-injection" >}}
+[node]: {{< ref "deploy/application/javascript/by-framework/nodejs#environment-injection" >}}
+[java-war]: {{< ref "deploy/application/java/java-war#environment-injection" >}}
+[php]: {{< ref "deploy/application/php/php-apps#environment-injection" >}}
+[play-1]: {{< ref "deploy/application/java/by-framework/play-framework-1#environment-injection" >}}
+[play-2]: {{< ref "deploy/application/java/by-framework/play-framework-2#environment-injection" >}}
+[python]: {{< ref "deploy/application/python/python_apps#environment-injection" >}}
+[ruby]: {{< ref "deploy/application/ruby/ruby-rack#environment-injection" >}}
+[rust]: {{< ref "deploy/application/rust/rust#environment-injection" >}}
+[scala]: {{< ref "deploy/application/scala/scala#environment-injection" >}}
+[dotnet]: {{< ref "deploy/application/dotnet/dotnet#environment-injection" >}}
 {{</table>}}
 
-Please note that the variables are available at build-time, for
-runtimes that support build-time instructions, such as
+{{< alert "info" "Usage at build time" >}}
+Please note that the variables are available at build time
+for runtimes that support build time instructions, such as
 [Java WAR]({{< ref "deploy/application/java/java-war#environment-injection" >}}),
 [Play! Framework 1]({{< ref "deploy/application/java/by-framework/play-framework-1#environment-injection" >}}),
 [Play! Framework 2]({{< ref "deploy/application/java/by-framework/play-framework-2#environment-injection" >}})
 or [Scala]({{< ref "deploy/application/scala/scala#environment-injection" >}}).
+{{< /alert >}}


### PR DESCRIPTION
Everything is in the title 🙂

Now the page looks better and is better structured (especially lists).

I made sure that links are not broken with the usage of ["Reference-style links"](https://www.markdownguide.org/basic-syntax#reference-style-links) in Hugo shortcodes.