### PR TITLE
Add port 9000 Python trick

### DIFF
--- a/partials/language-specific-deploy/python.md
+++ b/partials/language-specific-deploy/python.md
@@ -14,6 +14,8 @@ The module (without .py) must be importable, i.e. be in `PYTHONPATH`. Basically,
 
 For example with *Flask*, it's gonna be the name of your main server file, followed by your Flask object: `server:app` for instance if you have a `server.py` file at the root of your project with a Flask `app` object inside.
 
+You can also use `CC_RUN_COMMAND` to launch Python application your way. In such case, it must listen on port `9000`.
+
 ### Choose Python version
 
 The default version of python on Clever Cloud is **2.7**. If you want to use python **3.x** instead, create an [environment variable](#setting-up-environment-variables-on-clever-cloud) `CC_PYTHON_VERSION` equal to either `3` (which will default to the most up-to-date version), `3.7`, `3.8`, `3.9`, `3.10` or `3.11`.

--- a/reference/reference-environment-variables.md
+++ b/reference/reference-environment-variables.md
@@ -307,6 +307,8 @@ If `TAILSCALE_LOGIN_SERVER` is provided, the agent will be configured to reach a
 |WSGI_WORKERS | Number of workers. (Defaut: automatically setup with the scaler size) |  |  |
 {{< /table >}}
 
+When your Python application doesn't use one of the supported backends, with `CC_RUN_COMMAND` for example, it must listen on port `9000`, not `8080`.
+
 ## Ruby
 
 [Ruby Documentation]({{< ref "deploy/application/ruby/ruby-rack.md" >}})


### PR DESCRIPTION
When a user deploy a Python application with a custom backend (via `CC_RUN_COMMAND` for example), it must listen on the 9000 port. I add this trick in the Python documentation and after the Python env var reference table. 