### PR TITLE
Add Java 21 version support

### DIFF
--- a/partials/java-versions.md
+++ b/partials/java-versions.md
@@ -7,7 +7,7 @@ Simply set the environment variable **CC_JAVA_VERSION** to the version you want.
     <p>New applications will have the <strong>CC_JAVA_VERSION</strong> environment variable set to 11.</p>
 {{< /alert >}}
 
-Accepted values are `7`, `8`, `11`, `17` or `graalvm-ce` (for GraalVM 21.0.0.2, based on OpenJDK 11.0).
+Accepted values are `7`, `8`, `11`, `17`, `21` or `graalvm-ce` (for GraalVM 21.0.0.2, based on OpenJDK 11.0).
 
 We follow the official Java [roadmap](https://www.oracle.com/java/technologies/java-se-support-roadmap.html) by supporting both LTS and latest non-LTS versions.
 


### PR DESCRIPTION
👋 Hello Clever Cloud Team !

Since Java version 21 is now officially supported ([announce on twitter](https://twitter.com/clever_cloudFR/status/1725525908860059908)), I added it to the doc.

Have a nice day 🙂
